### PR TITLE
ci: add Extras and CodeQL workflows (audit, web-ext lint, link check, smoke)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      dev-deps:
+        dependency-type: development

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: CodeQL
+
+# GitHub's free static analysis. Runs on every PR and push to main, plus
+# weekly to pick up new query-pack rules without waiting for a code change.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze JavaScript
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:${{ matrix.language }}'

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -54,7 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: lycheeverse/lychee-action@v2
+      # Pinned to commit SHA (not @v2 tag) so a compromised tag in the
+      # third-party action repo cannot run arbitrary code in our CI.
+      # Update SHA when bumping major versions; dependabot picks this up.
+      - uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
           args: --no-progress --verbose --max-concurrency 4 './README.md'
           fail: true

--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -1,0 +1,72 @@
+name: Extras
+
+# Secondary CI lane. Catches things the primary `ci.yml` workflow doesn't:
+# known CVEs in deps, manifest issues web-ext lint flags as warnings,
+# broken links in the README, and behavioral regressions in score-server.js
+# that lint can't see (auth gate, status codes).
+#
+# Runs on every PR and every push to main, plus weekly to surface drift
+# (new CVEs published, link rot).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: npm audit (high+)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run audit
+
+  webext-lint:
+    name: web-ext lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Pack into dist/
+        run: npm run pack
+      - name: Lint the packed extension
+        # Without --warnings-as-errors so Firefox-only style notices (e.g.
+        # MISSING_DATA_COLLECTION_PERMISSIONS) don't fail the build for a
+        # Chrome-targeted MV3 extension. Real ERRORS still fail.
+        run: npx --no-install web-ext lint --source-dir dist --self-hosted
+
+  links:
+    name: Markdown link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lycheeverse/lychee-action@v2
+        with:
+          args: --no-progress --verbose --max-concurrency 4 './README.md'
+          fail: true
+
+  smoke:
+    name: score-server smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run smoke

--- a/manifest.json
+++ b/manifest.json
@@ -13,5 +13,10 @@
   "host_permissions": [
     "https://*.linkedin.com/*",
     "http://127.0.0.1/*"
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "linkshit@replikanti.github.io"
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "check": "node --check score-server.js && node --check content.js",
     "validate": "node -e \"['manifest.json','package.json'].forEach(f => JSON.parse(require('fs').readFileSync(f,'utf8')))\"",
     "lint": "eslint .",
-    "pack": "node scripts/pack.js"
+    "pack": "node scripts/pack.js",
+    "smoke": "node scripts/smoke-server.js",
+    "audit": "npm audit --audit-level=high"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/smoke-server.js
+++ b/scripts/smoke-server.js
@@ -9,15 +9,22 @@ const path = require('node:path');
 const PORT = '7780';
 const TOKEN = 'smoketok';
 
-const stubPath = path.join(os.tmpdir(), `linkshit-stub-${process.pid}.sh`);
+// `fs.mkdtempSync` atomically creates a unique directory in /tmp owned only
+// by us, so writing the stub inside it is not vulnerable to a TOCTOU /
+// symlink-swap attack on a predictable temp path.
+const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'linkshit-smoke-'));
+const stubPath = path.join(stubDir, 'stub-claude.sh');
 fs.writeFileSync(
   stubPath,
   '#!/bin/bash\necho \'[{"id":1,"score":5,"reason":"stub"}]\'\n',
   { mode: 0o755 },
 );
 
+// Use `process.execPath` (the absolute path of the node binary running this
+// script) instead of relying on $PATH lookup for "node". Avoids the security
+// rule about world-writable PATH directories shadowing a known command.
 const proc = spawn(
-  'node',
+  process.execPath,
   ['score-server.js'],
   {
     env: { ...process.env, LINKSHIT_TOKEN: TOKEN, PORT, CLAUDE_BIN: stubPath },
@@ -33,7 +40,7 @@ proc.stderr.on('data', d => { serverErr += d; });
 
 const cleanup = () => {
   try { proc.kill('SIGTERM'); } catch { /* already gone */ }
-  try { fs.unlinkSync(stubPath); } catch { /* already gone */ }
+  try { fs.rmSync(stubDir, { recursive: true, force: true }); } catch { /* already gone */ }
 };
 
 const fail = msg => {

--- a/scripts/smoke-server.js
+++ b/scripts/smoke-server.js
@@ -43,10 +43,14 @@ const cleanup = () => {
   try { fs.rmSync(stubDir, { recursive: true, force: true }); } catch { /* already gone */ }
 };
 
+// Sonar S5145 (log injection) on the two server-output lines is a false
+// positive here: this is a CI smoke script printing a child process's own
+// stdout/stderr to the runner's stderr for diagnostic purposes — there is
+// no log-analyzer downstream that could be fooled by CRLF injection.
 const fail = msg => {
-  console.error('SMOKE FAIL:', msg);
-  if (serverOut) console.error('--- server stdout ---\n' + serverOut);
-  if (serverErr) console.error('--- server stderr ---\n' + serverErr);
+  console.error('SMOKE FAIL:', msg); // NOSONAR
+  if (serverOut) console.error('--- server stdout ---\n' + serverOut); // NOSONAR
+  if (serverErr) console.error('--- server stderr ---\n' + serverErr); // NOSONAR
   cleanup();
   process.exit(1);
 };

--- a/scripts/smoke-server.js
+++ b/scripts/smoke-server.js
@@ -1,0 +1,98 @@
+// Boot score-server.js with a stub LLM, exercise the auth flow, exit 0/1.
+// CI smoke test — runs in extras.yml and locally via `npm run smoke`.
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const PORT = '7780';
+const TOKEN = 'smoketok';
+
+const stubPath = path.join(os.tmpdir(), `linkshit-stub-${process.pid}.sh`);
+fs.writeFileSync(
+  stubPath,
+  '#!/bin/bash\necho \'[{"id":1,"score":5,"reason":"stub"}]\'\n',
+  { mode: 0o755 },
+);
+
+const proc = spawn(
+  'node',
+  ['score-server.js'],
+  {
+    env: { ...process.env, LINKSHIT_TOKEN: TOKEN, PORT, CLAUDE_BIN: stubPath },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    cwd: path.resolve(__dirname, '..'),
+  },
+);
+
+let serverOut = '';
+let serverErr = '';
+proc.stdout.on('data', d => { serverOut += d; });
+proc.stderr.on('data', d => { serverErr += d; });
+
+const cleanup = () => {
+  try { proc.kill('SIGTERM'); } catch { /* already gone */ }
+  try { fs.unlinkSync(stubPath); } catch { /* already gone */ }
+};
+
+const fail = msg => {
+  console.error('SMOKE FAIL:', msg);
+  if (serverOut) console.error('--- server stdout ---\n' + serverOut);
+  if (serverErr) console.error('--- server stderr ---\n' + serverErr);
+  cleanup();
+  process.exit(1);
+};
+
+const waitListen = async () => {
+  for (let i = 0; i < 50; i++) {
+    if (serverOut.includes('Linkshit score server')) return;
+    await new Promise(r => setTimeout(r, 100));
+  }
+  fail('server did not start within 5s');
+};
+
+const post = (token) => fetch(`http://127.0.0.1:${PORT}/score`, {
+  method: 'POST',
+  headers: {
+    'content-type': 'application/json',
+    ...(token ? { 'x-linkshit-token': token } : {}),
+  },
+  body: JSON.stringify({
+    criteria: 'smoke',
+    posts: [{ author: 'A', text: 'hello hello hello hello hello hello', reactions: 0 }],
+  }),
+});
+
+const checks = async () => {
+  await waitListen();
+
+  const r1 = await post(null);
+  if (r1.status !== 401) fail(`no-token: expected 401, got ${r1.status}`);
+
+  const r2 = await post('wrong');
+  if (r2.status !== 401) fail(`wrong-token: expected 401, got ${r2.status}`);
+
+  const r3 = await post(TOKEN);
+  if (r3.status !== 200) {
+    const body = await r3.text();
+    fail(`valid-token: expected 200, got ${r3.status}: ${body}`);
+  }
+  const body = await r3.json();
+  if (!Array.isArray(body) || body.length !== 1 || body[0].id !== 1) {
+    fail(`valid-token: unexpected body: ${JSON.stringify(body)}`);
+  }
+
+  const r4 = await fetch(`http://127.0.0.1:${PORT}/score`, { method: 'OPTIONS' });
+  if (r4.status !== 200) fail(`OPTIONS: expected 200, got ${r4.status}`);
+  const allow = r4.headers.get('access-control-allow-headers') || '';
+  if (!allow.toLowerCase().includes('x-linkshit-token')) {
+    fail(`OPTIONS: missing x-linkshit-token in Allow-Headers: ${allow}`);
+  }
+
+  console.log('SMOKE OK: 4/4 assertions passed');
+  cleanup();
+  process.exit(0);
+};
+
+checks().catch(e => fail(e.message ?? String(e)));


### PR DESCRIPTION
## Summary

Adds two secondary CI workflows that catch issues the primary `ci.yml` doesn't, plus a manifest tweak so `web-ext lint` is happy with Chrome MV3.

### Extras workflow (`.github/workflows/extras.yml`)

| Job | Tool | What it catches |
|---|---|---|
| `audit` | `npm audit --audit-level=high` | High-severity CVEs in deps. Five existing moderate findings under `web-ext` → `addons-linter` (`ajv`, `uuid`, `node-notifier`) accepted as dev-tree noise. |
| `webext-lint` | `web-ext lint` against the packed `dist/` bundle | Manifest issues (missing required fields, invalid permissions). |
| `links` | `lycheeverse/lychee-action@v2` on `README.md` | Link rot. |
| `smoke` | `scripts/smoke-server.js` | Real behavior of `score-server.js` — boots, exercises auth gate (no token → 401, wrong token → 401, valid token → 200, OPTIONS preflight returns 200 with `x-linkshit-token` in `Access-Control-Allow-Headers`). |

Triggers: every PR, every push to `main`, weekly Monday 06:00 UTC (drift / new CVEs / link rot / new CodeQL queries).

### CodeQL workflow (`.github/workflows/codeql.yml`)

GitHub's free static analysis on the JS sources, `security-and-quality` query pack. Own file because it needs `security-events: write` which the primary workflow doesn't have.

### Manifest change

- Added `browser_specific_settings.gecko.id = "linkshit@replikanti.github.io"` so MV3 `EXTENSION_ID_REQUIRED` stops failing in `web-ext lint`. Field is Firefox-only; Chrome ignores it. Bonus: future Firefox port works without further changes.
- Dropped `--warnings-as-errors` from the lint step so Firefox-only notices (`MISSING_DATA_COLLECTION_PERMISSIONS`) don't fail the build for a Chrome-targeted extension. Real errors still fail.

## Verified locally

- `npm run audit` → 0 high, 5 moderate (dev tree only) — exit 0.
- `web-ext lint` after pack → 0 errors, 1 notice, exit 0.
- `npm run smoke` → 4/4 assertions passed.
- `npm run check` / `validate` / `lint` / `pack` all green.

## Out of scope

- Smoke test on macOS / Windows runners. Linux only for now; could be added if anyone reports a bash-stub-related platform issue.
- Performance/bundle-size guard. Trivial to add later if the bundle starts bloating.

## Test plan

- [ ] `extras.yml` shows up under Actions and goes green for each of its four jobs
- [ ] `codeql.yml` shows up under Actions and the security tab populates
- [ ] No drift in primary `ci.yml` results — still green