### PR TITLE
feat: non-tech-friendly installer + GitHub Releases pipeline (refs #10)

### DIFF
--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -49,6 +49,14 @@ jobs:
         # Chrome-targeted MV3 extension. Real ERRORS still fail.
         run: npx --no-install web-ext lint --source-dir dist --self-hosted
 
+  shellcheck:
+    name: shellcheck installer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: ShellCheck install.sh
+        run: shellcheck installers/install.sh
+
   links:
     name: Markdown link check
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,24 +42,40 @@ jobs:
           # Encode host.js as base64 (single line, no wrap) and substitute
           # into the installer template. Use `|` as the sed delimiter since
           # the base64 alphabet (A-Za-z0-9+/=) does not include it.
+          #
+          # The sed is anchored to the assignment line (`^readonly
+          # LINKSHIT_HOST_JS_BASE64=`) so it only rewrites that one place
+          # and never accidentally touches another occurrence of the
+          # placeholder elsewhere in the script (would-be bug: a string
+          # comparison line would be substituted too and silently neutralise
+          # the embedding, dragging every released installer back onto the
+          # network-fallback branch).
           HOST_B64=$(base64 -w0 host.js)
-          sed "s|__HOST_JS_BASE64__|${HOST_B64}|" \
+          sed "/^readonly LINKSHIT_HOST_JS_BASE64=/s|__HOST_JS_BASE64__|${HOST_B64}|" \
             installers/install.sh > installers/install.release.sh
           chmod +x installers/install.release.sh
-          # Sanity-check: parse the generated script.
+
+          # Verify: parses, placeholder gone from the assignment line, blob
+          # round-trips byte-for-byte, and the embedded blob is long enough
+          # that install.sh's runtime length-based detection takes the
+          # embedded branch (not the network fallback).
           bash -n installers/install.release.sh
-          # And spot-check that the placeholder is gone and the encoded
-          # blob round-trips back to the original host.js.
-          if grep -q '__HOST_JS_BASE64__' installers/install.release.sh; then
-            echo "ERROR: placeholder still present after substitution" >&2
+          if grep -q '^readonly LINKSHIT_HOST_JS_BASE64="__HOST_JS_BASE64__"$' installers/install.release.sh; then
+            echo "ERROR: assignment-line placeholder not substituted" >&2
             exit 1
           fi
-          ENCODED=$(grep -oP 'LINKSHIT_HOST_JS_BASE64="\K[^"]+' installers/install.release.sh)
+          ENCODED=$(grep -oP '^readonly LINKSHIT_HOST_JS_BASE64="\K[^"]+' installers/install.release.sh)
           echo "$ENCODED" | base64 -d | diff -q - host.js || {
             echo "ERROR: embedded host.js does not round-trip to source" >&2
             exit 1
           }
-          echo "✓ install.release.sh built and verified"
+          if [ "${#ENCODED}" -lt 200 ]; then
+            echo "ERROR: embedded base64 is only ${#ENCODED} chars; install.sh's" >&2
+            echo "       length-based template detection (<200) would route this" >&2
+            echo "       installer to the network-fallback path." >&2
+            exit 1
+          fi
+          echo "✓ install.release.sh built and verified (${#ENCODED} chars embedded)"
 
       - name: Create GitHub Release with assets
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+name: Release
+
+# Triggered when a tag matching v* is pushed. Builds the extension zip,
+# embeds host.js into the installer template, and publishes everything as
+# attached assets on a GitHub Release.
+#
+# Assets shipped on each release:
+#   - linkshit-extension-vX.Y.Z.zip   (Chrome MV3 unpacked extension)
+#   - host.js                         (raw, for advanced users)
+#   - install.sh                      (embedded host.js inline; user runs this)
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Pack the extension
+        run: |
+          npm run pack
+          # Rename to include the tag for clarity in the Releases UI.
+          mv "$(ls web-ext-artifacts/linkshit-*.zip)" \
+             "web-ext-artifacts/linkshit-extension-${GITHUB_REF_NAME}.zip"
+
+      - name: Embed host.js into install.sh
+        run: |
+          # Encode host.js as base64 (single line, no wrap) and substitute
+          # into the installer template. Use `|` as the sed delimiter since
+          # the base64 alphabet (A-Za-z0-9+/=) does not include it.
+          HOST_B64=$(base64 -w0 host.js)
+          sed "s|__HOST_JS_BASE64__|${HOST_B64}|" \
+            installers/install.sh > installers/install.release.sh
+          chmod +x installers/install.release.sh
+          # Sanity-check: parse the generated script.
+          bash -n installers/install.release.sh
+          # And spot-check that the placeholder is gone and the encoded
+          # blob round-trips back to the original host.js.
+          if grep -q '__HOST_JS_BASE64__' installers/install.release.sh; then
+            echo "ERROR: placeholder still present after substitution" >&2
+            exit 1
+          fi
+          ENCODED=$(grep -oP 'LINKSHIT_HOST_JS_BASE64="\K[^"]+' installers/install.release.sh)
+          echo "$ENCODED" | base64 -d | diff -q - host.js || {
+            echo "ERROR: embedded host.js does not round-trip to source" >&2
+            exit 1
+          }
+          echo "✓ install.release.sh built and verified"
+
+      - name: Create GitHub Release with assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            "web-ext-artifacts/linkshit-extension-${GITHUB_REF_NAME}.zip" \
+            "host.js" \
+            "installers/install.release.sh#install.sh"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,56 @@ Claude Pro/Max subscription (no API tokens, no per-call cost). Replace one
 function in `host.js` and you can point it at the Anthropic API, Ollama, or
 anything else.
 
-> **Heads-up.** A non-technical one-click installer is in the oven (issue
-> [#10](https://github.com/Replikanti/linkshit/issues/10), shipping with
-> v0.2.0). Until then the setup below is developer-grade — you write the
-> Chrome native messaging manifest once by hand.
+## Quick Start (5 minutes, no terminal commands to memorize)
+
+> Linux and macOS only. Windows is intentionally not supported.
+
+### 1. Run the installer
+
+Download `install.sh` from the [latest release](https://github.com/Replikanti/linkshit/releases/latest), then in a terminal:
+
+```bash
+bash ~/Downloads/install.sh
+```
+
+The installer will:
+
+1. Verify Node.js 22+ is installed (and tell you where to get it if not).
+2. Install the `claude` CLI globally (Claude Code; ships your Pro/Max OAuth login).
+3. Drop `host.js` into `~/.linkshit/`.
+4. Register Chrome's native messaging manifest in the right OS-specific path.
+
+If the script tells you to log in to Claude Code first, open a new terminal,
+run `claude`, finish the sign-in flow in your browser, type `/exit`, then
+re-run `install.sh`.
+
+### 2. Load the extension in Chrome
+
+Download `linkshit-extension-vX.Y.Z.zip` from the same release, unzip it
+somewhere stable (e.g. `~/Linkshit/`).
+
+Open `chrome://extensions` and turn **Developer mode** on (top right):
+
+![Step 1 — turn Developer mode on](docs/screenshots/01-extensions-dev-mode.svg)
+
+Then click **Load unpacked** and pick the unzipped folder:
+
+![Step 2 — Load unpacked, select folder](docs/screenshots/02-load-unpacked.svg)
+
+### 3. Use it
+
+Visit [`linkedin.com/feed`](https://www.linkedin.com/feed). A panel appears
+top-right. Click ⚙, set your **Criteria** (one or two sentences describing
+what's worth surfacing), Save, then **Start**.
+
+![The Linkshit panel on a LinkedIn feed page](docs/screenshots/03-panel-on-linkedin.svg)
+
+Hits stream in sorted by score. Click **Open on LinkedIn →** on any of them
+to jump to the post.
+
+> **Note on the screenshots above.** They are mockups, not real Chrome
+> captures — Linkshit's CI does not run a browser. Replace the SVGs in
+> `docs/screenshots/` with real PNGs whenever convenient.
 
 ## How it works
 
@@ -65,7 +111,10 @@ in `manifest.json`).
   complete the OAuth login).
 - **Google Chrome** (or Chromium-based browser with MV3 support).
 
-## Setup (manual, until v0.2.0 ships an installer)
+## Manual setup (developer-grade)
+
+If you'd rather skip `install.sh` (e.g. you cloned the repo and want to
+hack on it), here's what the installer does, broken out by step.
 
 ### 1. Clone the repo and install dev tooling
 
@@ -92,7 +141,6 @@ Pick the path for your OS:
 
 - **Linux:** `~/.config/google-chrome/NativeMessagingHosts/com.replikanti.linkshit.json`
 - **macOS:** `~/Library/Application Support/Google/Chrome/NativeMessagingHosts/com.replikanti.linkshit.json`
-- **Windows:** registered via a registry key under `HKCU\Software\Google\Chrome\NativeMessagingHosts\com.replikanti.linkshit` (see [Chrome docs](https://developer.chrome.com/docs/extensions/develop/concepts/native-messaging))
 
 Write this JSON (replacing `/full/path/to/host.js` with the absolute path
 to `host.js` in your clone):
@@ -223,7 +271,7 @@ The browser-side code never changes.
 | `Error: failed to connect to native host: …` | Same family — manifest exists but Chrome rejected it. Often the `allowed_origins` doesn't list the right extension ID. Confirm the extension ID at `chrome://extensions` matches `pgcnimcldmdfkemofhjfnemieckciche`. |
 | `Error: claude exit …` | `claude` not in PATH or not logged in. Run `claude` manually first. |
 | Quota exhausted mid-session | See Cost / quota. |
-| `Error: claude exit 1` with no stderr | Try `CLAUDE_MODEL=sonnet` — `haiku` may not be available on your plan. Set the env var in the wrapper that invokes the host (see installer in PR-B). |
+| `Error: claude exit 1` with no stderr | Try `CLAUDE_MODEL=sonnet` — `haiku` may not be available on your plan. Edit `~/.linkshit/host.js` and set `MODEL` accordingly, or wrap `host.js` in a tiny script that exports the env var before exec'ing the real one. |
 
 ## Files
 
@@ -231,11 +279,14 @@ The browser-side code never changes.
 - `content.js` — extension content script (UI + scroll + extract + dedupe)
 - `background.js` — service worker bridging content script to native messaging host
 - `host.js` — Node native messaging host; `runLLM()` is the swap point
+- `installers/install.sh` — one-shot Linux/macOS installer template (host.js gets embedded inline at release time)
+- `docs/screenshots/` — illustrative SVG mockups of the Chrome and LinkedIn steps
 - `package.json` — Node metadata (runtime has no deps; dev tooling only)
 - `eslint.config.mjs` — ESLint flat config
 - `.github/workflows/ci.yml` — CI pipeline (validate / check / lint / pack)
-- `.github/workflows/extras.yml` — extras (audit / web-ext lint / link check / smoke)
+- `.github/workflows/extras.yml` — extras (audit / web-ext lint / link check / shellcheck)
 - `.github/workflows/codeql.yml` — CodeQL static analysis
+- `.github/workflows/release.yml` — tag-triggered release: builds extension zip, embeds host.js into install.sh, attaches all three to a GitHub Release
 
 ## Development
 

--- a/docs/screenshots/01-extensions-dev-mode.svg
+++ b/docs/screenshots/01-extensions-dev-mode.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 380" font-family="-apple-system, system-ui, sans-serif">
+  <rect width="800" height="380" fill="#f1f3f4"/>
+  <!-- Top bar -->
+  <rect x="0" y="0" width="800" height="56" fill="#ffffff" stroke="#dadce0"/>
+  <text x="20" y="36" font-size="22" fill="#202124">Extensions</text>
+  <!-- Developer mode toggle (highlighted) -->
+  <rect x="540" y="14" width="240" height="32" rx="6" fill="#fff" stroke="#1a73e8" stroke-width="3"/>
+  <text x="552" y="34" font-size="14" fill="#202124">Developer mode</text>
+  <rect x="734" y="20" width="38" height="20" rx="10" fill="#1a73e8"/>
+  <circle cx="762" cy="30" r="8" fill="#fff"/>
+  <text x="540" y="74" font-size="12" fill="#1a73e8" font-weight="600">① Toggle this ON</text>
+  <!-- Sub-bar with Load unpacked button (dimmed in this step) -->
+  <rect x="0" y="56" width="800" height="50" fill="#fff" stroke="#dadce0"/>
+  <rect x="20" y="68" width="120" height="28" rx="14" fill="#fff" stroke="#dadce0"/>
+  <text x="36" y="86" font-size="13" fill="#5f6368">Load unpacked</text>
+  <rect x="150" y="68" width="120" height="28" rx="14" fill="#fff" stroke="#dadce0"/>
+  <text x="170" y="86" font-size="13" fill="#5f6368">Pack extension</text>
+  <rect x="280" y="68" width="120" height="28" rx="14" fill="#fff" stroke="#dadce0"/>
+  <text x="298" y="86" font-size="13" fill="#5f6368">Update</text>
+  <!-- URL bar context -->
+  <text x="20" y="138" font-size="14" fill="#5f6368">URL:</text>
+  <rect x="60" y="124" width="220" height="22" rx="3" fill="#fff" stroke="#dadce0"/>
+  <text x="68" y="140" font-size="13" fill="#202124" font-family="monospace">chrome://extensions</text>
+  <!-- Empty state -->
+  <text x="400" y="240" font-size="18" fill="#5f6368" text-anchor="middle">No extensions installed yet.</text>
+  <text x="400" y="262" font-size="14" fill="#80868b" text-anchor="middle">After turning Developer mode on, the "Load unpacked" button activates.</text>
+  <!-- Footer note -->
+  <rect x="0" y="332" width="800" height="48" fill="#e8f0fe"/>
+  <text x="400" y="360" font-size="13" fill="#1967d2" text-anchor="middle">Step 1 of 2 — turn Developer mode ON, then continue with the next screenshot.</text>
+</svg>

--- a/docs/screenshots/02-load-unpacked.svg
+++ b/docs/screenshots/02-load-unpacked.svg
@@ -1,0 +1,32 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 380" font-family="-apple-system, system-ui, sans-serif">
+  <rect width="800" height="380" fill="#f1f3f4"/>
+  <!-- Top bar -->
+  <rect x="0" y="0" width="800" height="56" fill="#ffffff" stroke="#dadce0"/>
+  <text x="20" y="36" font-size="22" fill="#202124">Extensions</text>
+  <!-- Developer mode toggle (now ON) -->
+  <rect x="540" y="14" width="240" height="32" rx="6" fill="#fff" stroke="#dadce0"/>
+  <text x="552" y="34" font-size="14" fill="#202124">Developer mode</text>
+  <rect x="734" y="20" width="38" height="20" rx="10" fill="#1a73e8"/>
+  <circle cx="762" cy="30" r="8" fill="#fff"/>
+  <!-- Sub-bar — Load unpacked highlighted -->
+  <rect x="0" y="56" width="800" height="50" fill="#fff" stroke="#dadce0"/>
+  <rect x="20" y="64" width="124" height="32" rx="16" fill="#e8f0fe" stroke="#1a73e8" stroke-width="3"/>
+  <text x="36" y="84" font-size="13" fill="#1a73e8" font-weight="600">Load unpacked</text>
+  <text x="20" y="124" font-size="12" fill="#1a73e8" font-weight="600">② Click this</text>
+  <rect x="150" y="68" width="120" height="28" rx="14" fill="#fff" stroke="#dadce0"/>
+  <text x="170" y="86" font-size="13" fill="#5f6368">Pack extension</text>
+  <rect x="280" y="68" width="120" height="28" rx="14" fill="#fff" stroke="#dadce0"/>
+  <text x="298" y="86" font-size="13" fill="#5f6368">Update</text>
+  <!-- File picker dialog mockup -->
+  <rect x="200" y="160" width="400" height="160" rx="8" fill="#fff" stroke="#dadce0" stroke-width="2"/>
+  <text x="220" y="190" font-size="14" fill="#202124" font-weight="600">Select Folder</text>
+  <line x1="220" y1="200" x2="580" y2="200" stroke="#dadce0"/>
+  <text x="220" y="230" font-size="13" fill="#5f6368">Browse to where you unzipped</text>
+  <text x="220" y="250" font-size="13" fill="#5f6368">linkshit-extension-vX.Y.Z.zip</text>
+  <text x="220" y="280" font-size="12" fill="#80868b" font-family="monospace">~/Downloads/linkshit-extension-v0.2.0/</text>
+  <rect x="490" y="290" width="80" height="22" rx="3" fill="#1a73e8"/>
+  <text x="530" y="306" font-size="13" fill="#fff" text-anchor="middle">Select</text>
+  <!-- Footer note -->
+  <rect x="0" y="332" width="800" height="48" fill="#e8f0fe"/>
+  <text x="400" y="360" font-size="13" fill="#1967d2" text-anchor="middle">Step 2 of 2 — click Load unpacked, pick the unzipped folder.</text>
+</svg>

--- a/docs/screenshots/03-panel-on-linkedin.svg
+++ b/docs/screenshots/03-panel-on-linkedin.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 480" font-family="-apple-system, system-ui, sans-serif">
+  <rect width="900" height="480" fill="#f3f2ef"/>
+  <!-- LinkedIn top bar -->
+  <rect x="0" y="0" width="900" height="56" fill="#ffffff" stroke="#e0dfdc"/>
+  <rect x="20" y="14" width="28" height="28" rx="4" fill="#0a66c2"/>
+  <text x="34" y="34" font-size="18" fill="#fff" text-anchor="middle" font-weight="700">in</text>
+  <rect x="60" y="16" width="220" height="24" rx="3" fill="#eef3f8" stroke="#dce6f1"/>
+  <text x="68" y="32" font-size="12" fill="#5e6064">Search</text>
+  <!-- Feed column -->
+  <rect x="100" y="76" width="500" height="160" rx="8" fill="#fff" stroke="#e0dfdc"/>
+  <circle cx="124" cy="100" r="14" fill="#cfd2d6"/>
+  <text x="148" y="100" font-size="13" fill="#000" font-weight="600">Some Person</text>
+  <text x="148" y="116" font-size="11" fill="#5e6064">Founder · 2h</text>
+  <text x="116" y="148" font-size="12" fill="#000">Yet another generic motivational post about leadership</text>
+  <text x="116" y="166" font-size="12" fill="#000">that you definitely want Linkshit to skip.</text>
+  <text x="116" y="200" font-size="11" fill="#5e6064">42 reactions · 7 comments</text>
+  <rect x="100" y="252" width="500" height="160" rx="8" fill="#fff" stroke="#e0dfdc"/>
+  <circle cx="124" cy="276" r="14" fill="#cfd2d6"/>
+  <text x="148" y="276" font-size="13" fill="#000" font-weight="600">Another Person</text>
+  <text x="148" y="292" font-size="11" fill="#5e6064">Engineer · 1h</text>
+  <text x="116" y="324" font-size="12" fill="#000">First-person story about hiring an AI engineering team</text>
+  <text x="116" y="342" font-size="12" fill="#000">at a Czech startup, with concrete sourcing tactics.</text>
+  <text x="116" y="376" font-size="11" fill="#5e6064">280 reactions · 35 comments</text>
+  <!-- Linkshit panel -->
+  <rect x="640" y="76" width="240" height="380" rx="8" fill="#fff" stroke="#dadce0" stroke-width="2"/>
+  <rect x="640" y="76" width="240" height="36" rx="8" fill="#fff" stroke="#eee"/>
+  <text x="654" y="100" font-size="13" fill="#000" font-weight="600">Linkshit</text>
+  <rect x="710" y="84" width="44" height="20" rx="3" fill="#0a66c2"/>
+  <text x="732" y="98" font-size="11" fill="#fff" text-anchor="middle">Start</text>
+  <rect x="758" y="84" width="42" height="20" rx="3" fill="#f5f5f5" stroke="#aaa"/>
+  <text x="779" y="98" font-size="11" fill="#202124" text-anchor="middle">Stop</text>
+  <rect x="804" y="84" width="22" height="20" rx="3" fill="#f5f5f5" stroke="#aaa"/>
+  <text x="815" y="98" font-size="11" fill="#202124" text-anchor="middle">⚙</text>
+  <!-- counters -->
+  <rect x="640" y="112" width="240" height="28" fill="#fafafa" stroke="#eee"/>
+  <text x="652" y="130" font-size="10" fill="#666">captured 42  ·  queued 6  ·  scored 18  ·  hits 3</text>
+  <!-- status -->
+  <rect x="640" y="140" width="240" height="22" fill="#fafafa" stroke="#eee"/>
+  <text x="652" y="156" font-size="11" fill="#555">Scrolling…</text>
+  <!-- one hit row -->
+  <rect x="640" y="172" width="240" height="78" fill="#fff" stroke="#f0f0f0"/>
+  <rect x="848" y="180" width="22" height="14" rx="2" fill="#0a66c2"/>
+  <text x="859" y="191" font-size="9" fill="#fff" text-anchor="middle">9</text>
+  <text x="652" y="190" font-size="11" fill="#000" font-weight="600">Another Person</text>
+  <text x="652" y="206" font-size="10" fill="#555" font-style="italic">First-person story on AI hiring</text>
+  <text x="652" y="220" font-size="10" fill="#555" font-style="italic">at a Czech startup — exactly</text>
+  <text x="652" y="234" font-size="10" fill="#555" font-style="italic">your stated criterion.</text>
+  <text x="652" y="248" font-size="10" fill="#0a66c2">Open on LinkedIn →</text>
+  <rect x="640" y="252" width="240" height="48" fill="#fff" stroke="#f0f0f0"/>
+  <rect x="848" y="260" width="22" height="14" rx="2" fill="#0a66c2"/>
+  <text x="859" y="271" font-size="9" fill="#fff" text-anchor="middle">7</text>
+  <text x="652" y="270" font-size="11" fill="#000" font-weight="600">Yet Another Person</text>
+  <text x="652" y="286" font-size="10" fill="#555" font-style="italic">Tangential but worth a glance.</text>
+  <!-- arrow / annotation -->
+  <text x="612" y="120" font-size="14" fill="#1a73e8" font-weight="600" text-anchor="end">⟶</text>
+  <text x="606" y="98" font-size="11" fill="#1a73e8" font-weight="600" text-anchor="end">Linkshit panel</text>
+  <text x="606" y="112" font-size="11" fill="#1a73e8" font-weight="600" text-anchor="end">(top right of feed)</text>
+</svg>

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -100,7 +100,9 @@ If you have not logged in yet:
   5. Come back here
 
 EOF
-read -r -p "Are you already logged in to Claude Code? [y/N] " logged_in
+# Tolerate EOF (Ctrl-D, or `bash install.sh </dev/null`) so `set -e` doesn't
+# kill the script with no message; treat silent stdin as "no".
+read -r -p "Are you already logged in to Claude Code? [y/N] " logged_in || logged_in=""
 case "${logged_in}" in
   [Yy]*) ;;
   *)
@@ -114,7 +116,14 @@ echo
 echo "Installing host.js into ${INSTALL_DIR}/ ..."
 mkdir -p "${INSTALL_DIR}"
 
-if [ "${LINKSHIT_HOST_JS_BASE64}" = "__HOST_JS_BASE64__" ]; then
+# Template-vs-released detection by length, not by string equality with the
+# placeholder. The release workflow's `sed` replaces every occurrence of
+# __HOST_JS_BASE64__ — if we used a string-equality test, the comparison
+# literal here would be substituted too and the test would always be true,
+# defeating the whole point of embedding. A real base64 of host.js is a
+# few thousand chars; the unsubstituted placeholder is 21. 200 is a safe
+# middle threshold.
+if [ "${#LINKSHIT_HOST_JS_BASE64}" -lt 200 ]; then
   # Template form (running from a clone of the repo, before release): pull
   # host.js over the network from the latest release.
   if [ "${LINKSHIT_VERSION}" = "latest" ]; then

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# Linkshit installer for Linux and macOS.
+#
+# What it does:
+#   1. Verifies Node.js 22+ is installed.
+#   2. Installs the @anthropic-ai/claude-code CLI globally (needed for the
+#      Pro/Max subscription path).
+#   3. Drops host.js into ~/.linkshit/ and makes it executable.
+#   4. Writes the Chrome native messaging manifest into the OS-specific
+#      directory so Chrome knows how to spawn the host.
+#
+# After this script finishes, the only manual step left is loading the
+# extension zip in chrome://extensions (developer mode → Load unpacked).
+# See README "Quick Start" for that bit.
+#
+# When this script is published as a release asset by .github/workflows/release.yml,
+# the LINKSHIT_HOST_JS_BASE64 line below is rewritten to embed the actual
+# host.js inline. Running the unmodified template here in the repo falls
+# back to downloading host.js from the latest GitHub release.
+
+set -euo pipefail
+
+# ---------- Constants ----------
+readonly EXT_ID="pgcnimcldmdfkemofhjfnemieckciche"
+readonly HOST_NAME="com.replikanti.linkshit"
+readonly INSTALL_DIR="${HOME}/.linkshit"
+readonly HOST_PATH="${INSTALL_DIR}/host.js"
+readonly LINKSHIT_VERSION="${LINKSHIT_VERSION:-latest}"
+
+# Substituted at release time. Until then, this stays as the literal
+# placeholder string so we know to fall back to a network download.
+readonly LINKSHIT_HOST_JS_BASE64="__HOST_JS_BASE64__"
+
+# ---------- OS / browser detection ----------
+case "$(uname -s)" in
+  Linux*)
+    NM_DIR="${HOME}/.config/google-chrome/NativeMessagingHosts"
+    ;;
+  Darwin*)
+    NM_DIR="${HOME}/Library/Application Support/Google/Chrome/NativeMessagingHosts"
+    ;;
+  *)
+    echo "ERROR: unsupported OS: $(uname -s)" >&2
+    echo "       This installer supports Linux and macOS." >&2
+    echo "       Windows is not supported." >&2
+    exit 1
+    ;;
+esac
+
+# ---------- Banner ----------
+cat <<'EOF'
+==============================================================
+  Linkshit — non-technical installer
+==============================================================
+EOF
+
+# ---------- Step 1: Node.js ----------
+if ! command -v node >/dev/null 2>&1; then
+  cat <<EOF >&2
+ERROR: Node.js is not installed.
+
+Install Node.js 22 or later from https://nodejs.org and re-run this
+script. On macOS you can also install with Homebrew (\`brew install node\`),
+on Linux with your distro package manager (\`apt install nodejs\` etc.) or
+via nvm (https://github.com/nvm-sh/nvm).
+EOF
+  exit 1
+fi
+
+NODE_MAJOR=$(node -v | sed 's/^v//' | cut -d. -f1)
+if [ "${NODE_MAJOR}" -lt 22 ]; then
+  cat <<EOF >&2
+ERROR: Node.js ${NODE_MAJOR} is too old. Linkshit requires Node 22+.
+Found: $(node -v).
+EOF
+  exit 1
+fi
+echo "✓ Node.js $(node -v)"
+
+# ---------- Step 2: Claude Code CLI ----------
+if ! command -v claude >/dev/null 2>&1; then
+  echo
+  echo "Claude Code CLI is not installed. Installing globally via npm..."
+  npm install -g @anthropic-ai/claude-code
+  echo
+fi
+echo "✓ Claude Code: $(claude --version 2>/dev/null || echo installed)"
+
+# ---------- Step 3: Confirm OAuth login ----------
+cat <<EOF
+
+Linkshit needs your Claude Code account to be already logged in
+(Pro or Max subscription — there are no API tokens involved).
+
+If you have not logged in yet:
+  1. Open a new terminal window
+  2. Run:    claude
+  3. Complete the sign-in flow that opens in your browser
+  4. Type    /exit    to leave the chat
+  5. Come back here
+
+EOF
+read -r -p "Are you already logged in to Claude Code? [y/N] " logged_in
+case "${logged_in}" in
+  [Yy]*) ;;
+  *)
+    echo "OK — log in first, then re-run this installer."
+    exit 0
+    ;;
+esac
+
+# ---------- Step 4: Install host.js ----------
+echo
+echo "Installing host.js into ${INSTALL_DIR}/ ..."
+mkdir -p "${INSTALL_DIR}"
+
+if [ "${LINKSHIT_HOST_JS_BASE64}" = "__HOST_JS_BASE64__" ]; then
+  # Template form (running from a clone of the repo, before release): pull
+  # host.js over the network from the latest release.
+  if [ "${LINKSHIT_VERSION}" = "latest" ]; then
+    URL="https://github.com/Replikanti/linkshit/releases/latest/download/host.js"
+  else
+    URL="https://github.com/Replikanti/linkshit/releases/download/${LINKSHIT_VERSION}/host.js"
+  fi
+  echo "  fetching ${URL}"
+  if ! curl -fSL -o "${HOST_PATH}" "${URL}"; then
+    cat <<EOF >&2
+
+ERROR: failed to download host.js from ${URL}.
+
+If no release exists yet, this is expected — please use the released
+install.sh from the Releases page instead, which embeds host.js inline
+and needs no network. https://github.com/Replikanti/linkshit/releases
+EOF
+    exit 1
+  fi
+else
+  # Released form: host.js is embedded as base64 in this script.
+  printf '%s' "${LINKSHIT_HOST_JS_BASE64}" | base64 -d > "${HOST_PATH}"
+fi
+chmod +x "${HOST_PATH}"
+echo "✓ host.js installed"
+
+# ---------- Step 5: Native messaging manifest ----------
+echo
+echo "Registering native messaging host with Chrome..."
+mkdir -p "${NM_DIR}"
+cat > "${NM_DIR}/${HOST_NAME}.json" <<EOF
+{
+  "name": "${HOST_NAME}",
+  "description": "Linkshit native messaging host",
+  "path": "${HOST_PATH}",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://${EXT_ID}/"
+  ]
+}
+EOF
+echo "✓ Manifest written: ${NM_DIR}/${HOST_NAME}.json"
+
+# ---------- Done ----------
+cat <<EOF
+
+==============================================================
+  Done!
+==============================================================
+
+One more step — load the extension in Chrome:
+
+  1. Download the latest extension zip:
+     https://github.com/Replikanti/linkshit/releases/latest
+
+     Look for: linkshit-extension-vX.Y.Z.zip
+
+  2. Unzip it to a folder somewhere stable (it has to stay there —
+     Chrome reads from this location every time you open the browser).
+
+  3. Open  chrome://extensions
+
+  4. In the top right, turn on  Developer mode
+
+  5. Click  Load unpacked  and pick the folder you unzipped to.
+
+  6. Visit  https://www.linkedin.com/feed
+     A panel appears in the upper right. Click ⚙, set your criteria,
+     click Save, then Start.
+
+If anything fails, check README "Troubleshooting".
+EOF


### PR DESCRIPTION
## Summary

PR-B from [#10](https://github.com/Replikanti/linkshit/issues/10). After this lands and v0.2.0 is tagged, a non-technical user gets from "I want this" to "it works" by:

1. Downloading **`install.sh`** from the Releases page → running `bash install.sh`
2. Downloading **`linkshit-extension-vX.Y.Z.zip`** → unzipping → drag into `chrome://extensions` (Developer mode on)
3. Setting Criteria in the panel and clicking Start.

No `git clone`, no `npm install`, no manual native-messaging-manifest writing, no terminal command beyond `bash install.sh`. Linux + macOS only — Windows is intentionally out of scope.

## What's in this PR

### `installers/install.sh`

Single bash script. Installs Node-detected, Claude Code globally, drops `host.js` into `~/.linkshit/`, writes the Chrome native messaging manifest at the OS-specific path, prints the rest of the steps. Two ways to obtain `host.js`:

- **Released form** (`install.sh` from the Releases page): host.js is embedded inline as base64 in the script. No network fetch at install time.
- **Template form** (running from a clone): falls back to downloading host.js from the latest GitHub release.

### `.github/workflows/release.yml`

Tag-triggered (`v*`). Builds the extension zip, embeds host.js into `install.sh` (with round-trip verification), creates a GitHub Release via `gh release create`, attaches:

- `linkshit-extension-vX.Y.Z.zip`
- `host.js`
- `install.sh`

### `.github/workflows/extras.yml`

New `shellcheck` job — runs `shellcheck installers/install.sh` on every push and PR.

### `docs/screenshots/`

Three SVG mockups embedded in README:

| | |
|---|---|
| `01-extensions-dev-mode.svg` | chrome://extensions with Developer mode toggle highlighted |
| `02-load-unpacked.svg` | Same page with Load unpacked button + folder picker |
| `03-panel-on-linkedin.svg` | The Linkshit panel on a LinkedIn feed page |

Mockups, not real screenshots. README explicitly notes this and invites real PNGs as a follow-up.

### `README.md`

New **Quick Start** section at the top (3 steps, ~5 min, embeds the SVG mockups inline). Old developer setup demoted to **Manual setup (developer-grade)**. Files list and troubleshooting updated.

## Verified locally

- `npm run lint` / `check` / `validate` / `pack` — green.
- `shellcheck installers/install.sh` — clean.
- Python `yaml.safe_load` on `release.yml` — valid.
- **Embed simulation:** ran the same `sed` substitution the workflow does, parsed result with `bash -n`, asserted placeholder is gone, decoded the embedded base64, and `diff -q`'d against `host.js` — byte-for-byte match.

## Out of scope (queued for PR-C)

- Native-host smoke test in CI. The smoke job was removed in PR-A together with `score-server.js`; PR-C re-adds it pointed at `host.js` (driving the Native Messaging stdin/stdout protocol).

## Test plan

- [ ] CI green (ci, web-ext lint, npm audit, link check, shellcheck, CodeQL, SonarCloud)
- [ ] Tag v0.2.0 after merge → release workflow triggers → assets appear on the Releases page
- [ ] Reviewer downloads `install.sh` from the v0.2.0 release, runs it on a fresh Linux/macOS box, confirms the panel works on LinkedIn