### PR TITLE
feat: native messaging host smoke test (closes #10)

### DIFF
--- a/.github/workflows/extras.yml
+++ b/.github/workflows/extras.yml
@@ -1,9 +1,9 @@
 name: Extras
 
 # Secondary CI lane. Catches things the primary `ci.yml` workflow doesn't:
-# known CVEs in deps, manifest issues web-ext lint flags, and broken links
-# in the README. (A native messaging host smoke test is queued for PR-C
-# from #10 — it has to drive Chrome's stdin/stdout protocol.)
+# known CVEs in deps, manifest issues web-ext lint flags, broken links
+# in the README, shellcheck on the installer, and a smoke test that drives
+# host.js through the Chrome native messaging stdin/stdout protocol.
 #
 # Runs on every PR and every push to main, plus weekly to surface drift
 # (new CVEs published, link rot).
@@ -56,6 +56,18 @@ jobs:
       - uses: actions/checkout@v6
       - name: ShellCheck install.sh
         run: shellcheck installers/install.sh
+
+  smoke:
+    name: native host smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run smoke
 
   links:
     name: Markdown link check

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ The browser-side code never changes.
 - `package.json` — Node metadata (runtime has no deps; dev tooling only)
 - `eslint.config.mjs` — ESLint flat config
 - `.github/workflows/ci.yml` — CI pipeline (validate / check / lint / pack)
-- `.github/workflows/extras.yml` — extras (audit / web-ext lint / link check / shellcheck)
+- `.github/workflows/extras.yml` — extras (audit / web-ext lint / link check / shellcheck / smoke)
 - `.github/workflows/codeql.yml` — CodeQL static analysis
 - `.github/workflows/release.yml` — tag-triggered release: builds extension zip, embeds host.js into install.sh, attaches all three to a GitHub Release
 
@@ -296,6 +296,7 @@ npm run check      # node --check on the JS files
 npm run validate   # JSON files parse
 npm run lint       # eslint
 npm run pack       # builds web-ext-artifacts/linkshit-<version>.zip
+npm run smoke      # drives host.js through the Chrome native messaging protocol
 ```
 
 CI runs check / validate / lint / pack on every push and PR.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "validate": "node -e \"['manifest.json','package.json'].forEach(f => JSON.parse(require('fs').readFileSync(f,'utf8')))\"",
     "lint": "eslint .",
     "pack": "node scripts/pack.js",
+    "smoke": "node scripts/smoke-host.js",
     "audit": "npm audit --audit-level=high"
   },
   "engines": {

--- a/scripts/smoke-host.js
+++ b/scripts/smoke-host.js
@@ -13,7 +13,7 @@
 //   4. malformed JSON inside a frame is reported via {ok:false,error}
 //      (not silently dropped — the bug fixed during PR-A's QA round)
 //
-// Runs in the `score-server smoke test` job in extras.yml on every PR
+// Runs in the `native host smoke test` job in extras.yml on every PR
 // and push to main, and locally via `npm run smoke`.
 
 const { spawn } = require('node:child_process');
@@ -133,8 +133,9 @@ async function checks() {
   process.exit(0);
 }
 
-const watchdog = setTimeout(() => fail('test timeout (10 s)'), 10000);
+// Watchdog: fires only if checks() hangs. Both `process.exit()` calls in
+// checks() and fail() are synchronous, so a `.finally()` would never run
+// — the timer is killed by the process exit itself.
+setTimeout(() => fail('test timeout (10 s)'), 10000);
 
-checks()
-  .catch(e => fail(e.message ?? String(e)))
-  .finally(() => clearTimeout(watchdog));
+checks().catch(e => fail(e.message ?? String(e)));

--- a/scripts/smoke-host.js
+++ b/scripts/smoke-host.js
@@ -1,0 +1,140 @@
+// Native messaging smoke test for host.js.
+//
+// Drives host.js the way Chrome would: spawn it as a subprocess, write
+// length-prefixed JSON messages to its stdin, read length-prefixed JSON
+// from its stdout. Stubs `claude` so the test doesn't depend on the user
+// being logged in to Claude Code or having network access.
+//
+// Asserts the four behaviors of the native messaging plumbing that we
+// most want to keep working:
+//   1. happy-path scoring round-trip
+//   2. unknown message type is reported via {ok:false,error}
+//   3. missing posts is reported via {ok:false,error}
+//   4. malformed JSON inside a frame is reported via {ok:false,error}
+//      (not silently dropped — the bug fixed during PR-A's QA round)
+//
+// Runs in the `score-server smoke test` job in extras.yml on every PR
+// and push to main, and locally via `npm run smoke`.
+
+const { spawn } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const HOST_PATH = path.resolve(__dirname, '..', 'host.js');
+
+// Atomically create a temp dir owned only by us, then drop a stub `claude`
+// inside. Avoids the TOCTOU pitfall flagged by CodeQL on the previous
+// smoke script (which used a predictable os.tmpdir() + pid path).
+const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'linkshit-host-smoke-'));
+const stubPath = path.join(stubDir, 'claude');
+fs.writeFileSync(
+  stubPath,
+  '#!/bin/bash\necho \'[{"id":1,"score":7,"reason":"stub-ok"}]\'\n',
+  { mode: 0o755 },
+);
+
+const proc = spawn(process.execPath, [HOST_PATH], {
+  env: { ...process.env, CLAUDE_BIN: stubPath },
+  stdio: ['pipe', 'pipe', 'pipe'],
+});
+
+let stderr = '';
+proc.stderr.on('data', c => { stderr += c; });
+
+const cleanup = () => {
+  try { proc.kill('SIGTERM'); } catch { /* already gone */ }
+  try { fs.rmSync(stubDir, { recursive: true, force: true }); } catch { /* already gone */ }
+};
+
+const fail = msg => {
+  console.error('SMOKE FAIL:', msg);                // NOSONAR — diagnostic stderr from a CI test, no log-injection downstream
+  if (stderr) console.error('--- host stderr ---\n' + stderr);   // NOSONAR
+  cleanup();
+  process.exit(1);
+};
+
+// Read length-prefixed frames from host stdout.
+let inboundBuf = Buffer.alloc(0);
+let pendingResolve = null;
+
+proc.stdout.on('data', chunk => {
+  inboundBuf = Buffer.concat([inboundBuf, chunk]);
+  if (pendingResolve) {
+    const r = pendingResolve;
+    pendingResolve = null;
+    r();
+  }
+});
+
+async function readFrame() {
+  while (true) {
+    if (inboundBuf.length >= 4) {
+      const expected = inboundBuf.readUInt32LE(0);
+      if (inboundBuf.length >= 4 + expected) {
+        const json = inboundBuf.subarray(4, 4 + expected).toString('utf8');
+        inboundBuf = inboundBuf.subarray(4 + expected);
+        return JSON.parse(json);
+      }
+    }
+    await new Promise(resolve => { pendingResolve = resolve; });
+  }
+}
+
+function sendFrame(obj) {
+  const data = Buffer.from(JSON.stringify(obj), 'utf8');
+  const len = Buffer.alloc(4);
+  len.writeUInt32LE(data.length, 0);
+  proc.stdin.write(Buffer.concat([len, data]));
+}
+
+function sendRawFrame(bodyBytes) {
+  const len = Buffer.alloc(4);
+  len.writeUInt32LE(bodyBytes.length, 0);
+  proc.stdin.write(Buffer.concat([len, bodyBytes]));
+}
+
+async function checks() {
+  // 1. happy-path
+  sendFrame({
+    type: 'score',
+    criteria: 'smoke',
+    posts: [{ author: 'A', text: 'hello hello hello hello hello hello', reactions: 0 }],
+  });
+  const r1 = await readFrame();
+  if (!r1.ok) fail(`happy-path: expected ok=true, got ${JSON.stringify(r1)}`);
+  if (!Array.isArray(r1.result) || r1.result[0]?.id !== 1) {
+    fail(`happy-path: bad result shape: ${JSON.stringify(r1)}`);
+  }
+
+  // 2. unknown message type
+  sendFrame({ type: 'bogus' });
+  const r2 = await readFrame();
+  if (r2.ok || !r2.error?.includes('unknown message type')) {
+    fail(`unknown-type: expected error envelope, got ${JSON.stringify(r2)}`);
+  }
+
+  // 3. missing posts
+  sendFrame({ type: 'score', criteria: 'x' });
+  const r3 = await readFrame();
+  if (r3.ok || !r3.error?.includes('non-empty array')) {
+    fail(`missing-posts: expected error envelope, got ${JSON.stringify(r3)}`);
+  }
+
+  // 4. malformed JSON inside a frame
+  sendRawFrame(Buffer.from('{not valid json', 'utf8'));
+  const r4 = await readFrame();
+  if (r4.ok || !r4.error?.includes('malformed JSON')) {
+    fail(`malformed-json: expected error envelope, got ${JSON.stringify(r4)}`);
+  }
+
+  console.log('SMOKE OK: 4/4 assertions passed');
+  cleanup();
+  process.exit(0);
+}
+
+const watchdog = setTimeout(() => fail('test timeout (10 s)'), 10000);
+
+checks()
+  .catch(e => fail(e.message ?? String(e)))
+  .finally(() => clearTimeout(watchdog));


### PR DESCRIPTION
## Summary

PR-C from [#10](https://github.com/Replikanti/linkshit/issues/10) — the last of the three. CI now actually exercises `host.js` end-to-end on every push and PR, the way Chrome would.

Closes #10 once merged.

## What this PR does

### `scripts/smoke-host.js`

Spawns `host.js` as a subprocess, drives it through the Chrome Native Messaging stdin/stdout protocol (4-byte LE uint32 length + UTF-8 JSON), and asserts:

| | |
|---|---|
| 1 | Happy-path scoring → `{ok:true, result:[…]}` |
| 2 | Unknown message type → `{ok:false, error:"unknown message type"}` |
| 3 | Missing posts → `{ok:false, error:"…non-empty array"}` |
| 4 | Malformed JSON inside a frame → `{ok:false, error}` envelope, NOT silent exit (regression-pin for PR-A's QA-fix commit) |

`claude` is stubbed via `fs.mkdtempSync` (atomic, no TOCTOU) so the test never needs the user's Claude Code login or network. `process.execPath` is used instead of `node` via PATH for the same reason. 10 s watchdog so a hang doesn't hold CI hostage.

### `extras.yml`

New `native host smoke test` job. Same pattern as the other jobs (Node 22 + npm cache + `actions/checkout@v6` / `setup-node@v6`).

### Protect main ruleset

Updated via `gh api PUT` to require both new contexts:

- `native host smoke test` (this PR)
- `shellcheck installer` (added in PR-B but never enforced)

Total required checks now: 8.

### `package.json` + README

`npm run smoke` is back, now pointing at `scripts/smoke-host.js`. README Files list and Development section updated.

## Verified locally

- `npm run smoke`: 4/4 assertions in <2 s.
- `npm run lint` / `check` / `validate` / `pack`: green.
- `shellcheck installers/install.sh`: clean.

## Test plan

- [ ] CI green (8 required checks)
- [ ] Once merged, ready for `git tag v0.2.0` → release workflow runs → assets attach to the release