### PR TITLE
fix(release): rename install.release.sh -> install.sh on the release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,17 @@ jobs:
           fi
           echo "✓ install.release.sh built and verified (${#ENCODED} chars embedded)"
 
+      - name: Stage assets with their final user-facing names
+        run: |
+          # gh release create's `path#label` syntax sets a UI label only —
+          # the actual asset filename comes from the path. README points
+          # users at install.sh, so rename the built artifact to that.
+          mkdir -p release-assets
+          cp "web-ext-artifacts/linkshit-extension-${GITHUB_REF_NAME}.zip" release-assets/
+          cp host.js release-assets/host.js
+          cp installers/install.release.sh release-assets/install.sh
+          ls -la release-assets/
+
       - name: Create GitHub Release with assets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -84,6 +95,6 @@ jobs:
           gh release create "${GITHUB_REF_NAME}" \
             --title "${GITHUB_REF_NAME}" \
             --generate-notes \
-            "web-ext-artifacts/linkshit-extension-${GITHUB_REF_NAME}.zip" \
-            "host.js" \
-            "installers/install.release.sh#install.sh"
+            "release-assets/linkshit-extension-${GITHUB_REF_NAME}.zip" \
+            "release-assets/host.js" \
+            "release-assets/install.sh"


### PR DESCRIPTION
## Bug

v0.2.0 shipped with the installer named `install.release.sh` instead of `install.sh`. The README's Quick Start instructs:

```bash
bash ~/Downloads/install.sh
```

…which doesn't match what users actually download. The `install.sh` URL on v0.2.0 returns 404; only `install.release.sh` exists.

```
$ curl -sIL https://github.com/Replikanti/linkshit/releases/download/v0.2.0/install.sh | head -1
HTTP/2 404
$ curl -sIL https://github.com/Replikanti/linkshit/releases/download/v0.2.0/install.release.sh | head -1
HTTP/2 302
```

## Root cause

`release.yml`'s `gh release create` was given:

```
"installers/install.release.sh#install.sh"
```

The `#install.sh` was meant to rename the asset, but `#label` in `gh release create` is **only a UI display label** — the underlying asset filename comes from the path.

## Fix

Stage all three assets in a `release-assets/` directory under their final user-facing names **before** running `gh release create`. The release upload now matches the README.

## What this leaves open

`v0.2.0` itself is already published with the wrong asset name. Three options for cleanup, listed in declining destructiveness:

- **Delete the `v0.2.0` release + tag, then re-tag v0.2.0** after this PR merges. Cleanest, but destructive of a published release.
- **Tag `v0.2.1`** with the fix. Leaves a slightly-broken `v0.2.0` in history.
- **Edit the v0.2.0 release in-place**: download `install.release.sh`, re-upload as `install.sh`, delete the misnamed asset. Less destructive than full delete.

That decision goes to the human after CI passes.

## Test plan

- [ ] CI green