### PR TITLE
feat(installer): inline Claude Code login + macOS double-click .command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,19 @@ jobs:
         run: |
           # gh release create's `path#label` syntax sets a UI label only —
           # the actual asset filename comes from the path. README points
-          # users at install.sh, so rename the built artifact to that.
+          # users at install.sh / install.command, so rename the built
+          # artifact accordingly.
+          #
+          # install.sh and install.command are byte-identical. The .command
+          # extension is recognised by macOS Finder so a user can
+          # double-click it to run in Terminal; on Linux that doesn't apply
+          # so we keep .sh too.
           mkdir -p release-assets
           cp "web-ext-artifacts/linkshit-extension-${GITHUB_REF_NAME}.zip" release-assets/
           cp host.js release-assets/host.js
           cp installers/install.release.sh release-assets/install.sh
+          cp installers/install.release.sh release-assets/install.command
+          chmod +x release-assets/install.sh release-assets/install.command
           ls -la release-assets/
 
       - name: Create GitHub Release with assets
@@ -97,4 +105,5 @@ jobs:
             --generate-notes \
             "release-assets/linkshit-extension-${GITHUB_REF_NAME}.zip" \
             "release-assets/host.js" \
-            "release-assets/install.sh"
+            "release-assets/install.sh" \
+            "release-assets/install.command"

--- a/README.md
+++ b/README.md
@@ -20,22 +20,30 @@ anything else.
 
 ### 1. Run the installer
 
-Download `install.sh` from the [latest release](https://github.com/Replikanti/linkshit/releases/latest), then in a terminal:
+Grab the right file from the [latest release](https://github.com/Replikanti/linkshit/releases/latest):
+
+**macOS:** download `install.command`. Double-click it.
+
+> First time you double-click, macOS Gatekeeper may say *"cannot be opened
+> because it is from an unidentified developer"*. Right-click the file →
+> **Open** → **Open** in the dialog. You only have to do this once.
+
+**Linux:** download `install.sh` and run it:
 
 ```bash
 bash ~/Downloads/install.sh
 ```
 
-The installer will:
+The installer handles everything in one go:
 
-1. Verify Node.js 22+ is installed (and tell you where to get it if not).
-2. Install the `claude` CLI globally (Claude Code; ships your Pro/Max OAuth login).
-3. Drop `host.js` into `~/.linkshit/`.
-4. Register Chrome's native messaging manifest in the right OS-specific path.
-
-If the script tells you to log in to Claude Code first, open a new terminal,
-run `claude`, finish the sign-in flow in your browser, type `/exit`, then
-re-run `install.sh`.
+1. Verifies Node.js 22+ is installed (and points you at nodejs.org if not).
+2. Installs the `claude` CLI globally if missing.
+3. **Detects whether you're already logged in to Claude Code.** If not, it
+   opens the sign-in flow in your browser; the installer continues
+   automatically once you finish — no second terminal, no `/exit`, no manual
+   re-run.
+4. Drops `host.js` into `~/.linkshit/`.
+5. Registers Chrome's native messaging manifest in the right OS-specific path.
 
 ### 2. Load the extension in Chrome
 

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ in `manifest.json`).
 ## Prerequisites
 
 - **Node.js 22+** (the host runs on Node, ships with no runtime deps).
-- **[Claude Code](https://docs.claude.com/en/docs/claude-code)** installed
-  and signed in with a Pro or Max account (`claude` once interactively to
-  complete the OAuth login).
+- A Claude **Pro or Max subscription**. The installer handles installing
+  the [Claude Code](https://docs.claude.com/en/docs/claude-code) CLI and
+  the OAuth sign-in for you — you don't need to set it up beforehand.
 - **Google Chrome** (or Chromium-based browser with MV3 support).
 
 ## Manual setup (developer-grade)

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -86,30 +86,53 @@ if ! command -v claude >/dev/null 2>&1; then
 fi
 echo "✓ Claude Code: $(claude --version 2>/dev/null || echo installed)"
 
-# ---------- Step 3: Confirm OAuth login ----------
-cat <<EOF
+# ---------- Step 3: Claude Code login ----------
+echo
+echo "Checking your Claude Code login..."
 
-Linkshit needs your Claude Code account to be already logged in
+# `claude auth status --json` (default) prints `"loggedIn": true|false`.
+# Free check — does not consume subscription quota.
+is_logged_in() {
+  claude auth status 2>/dev/null | grep -q '"loggedIn"[[:space:]]*:[[:space:]]*true'
+}
+
+if is_logged_in; then
+  email=$(claude auth status 2>/dev/null | grep -oE '"email"[[:space:]]*:[[:space:]]*"[^"]+"' | sed -E 's/.*"([^"]+)"$/\1/' || true)
+  if [ -n "${email}" ]; then
+    echo "✓ Already logged in as ${email}"
+  else
+    echo "✓ Already logged in"
+  fi
+else
+  cat <<'EOF'
+
+Not logged in yet — Linkshit will now open Claude Code's sign-in flow.
+Your browser will pop up so you can sign in with your Anthropic account
 (Pro or Max subscription — there are no API tokens involved).
-
-If you have not logged in yet:
-  1. Open a new terminal window
-  2. Run:    claude
-  3. Complete the sign-in flow that opens in your browser
-  4. Type    /exit    to leave the chat
-  5. Come back here
+The installer will continue automatically once you're done.
 
 EOF
-# Tolerate EOF (Ctrl-D, or `bash install.sh </dev/null`) so `set -e` doesn't
-# kill the script with no message; treat silent stdin as "no".
-read -r -p "Are you already logged in to Claude Code? [y/N] " logged_in || logged_in=""
-case "${logged_in}" in
-  [Yy]*) ;;
-  *)
-    echo "OK — log in first, then re-run this installer."
-    exit 0
-    ;;
-esac
+  # Tolerate EOF (Ctrl-D, or `bash install.sh </dev/null`).
+  read -r -p "Press Enter to start the login (or Ctrl-C to cancel)..." _ || true
+
+  if ! claude auth login; then
+    cat <<EOF >&2
+
+ERROR: Claude Code login failed.
+Run \`claude auth login\` manually, then re-run this installer.
+EOF
+    exit 1
+  fi
+  if ! is_logged_in; then
+    cat <<EOF >&2
+
+ERROR: Claude Code reports it is still not logged in.
+Run \`claude auth login\` manually, then re-run this installer.
+EOF
+    exit 1
+  fi
+  echo "✓ Logged in"
+fi
 
 # ---------- Step 4: Install host.js ----------
 echo


### PR DESCRIPTION
## Why

After v0.2.0 shipped, the user flagged the install flow as still too complex for non-technical users (Pepa et al.). The two biggest remaining friction points were:

1. **The two-terminal Claude Code login dance.** v0.2.0's installer printed an instruction telling the user to open *another* terminal, run `claude`, complete OAuth, type `/exit`, come back, and answer `y` to a prompt. For someone who has never used a terminal, this is incomprehensible.
2. **`bash install.sh`.** The user has to know that `.sh` files are scripts, that you run them via `bash`, and how to invoke Terminal at all. macOS has a native solution to this: `.command` files. Linux doesn't.

This PR collapses both into one continuous flow.

## (1) Inline Claude Code login

Replaces the manual prompt with auto-detection via `claude auth status` (a free CLI command — JSON output with `loggedIn: true|false`, no subscription quota burned).

- **Already logged in:** prints `✓ Already logged in as <email>` and continues.
- **Not logged in:** brief explanation, single Enter to confirm, then runs `claude auth login` which opens the browser. After the user signs in, the installer verifies with another `claude auth status` and continues automatically.

The `Are you already logged in to Claude Code? [y/N]` prompt and the "open another terminal" instructions are gone entirely.

Verified locally: with the user's real `HOME`, the script reports `✓ Already logged in as mholy1983@gmail.com` and continues to host.js install. With an isolated `HOME` (no auth state), the script correctly enters the login flow.

## (2) macOS double-click installer

`release.yml` now ships `install.command` alongside `install.sh` — bytes are identical, only the extension differs. macOS Finder recognises `.command` and double-click opens it in Terminal automatically. First-run Gatekeeper warning is documented in README (Ctrl-click → Open).

Linux still gets `install.sh` since the `.command` convention is macOS-only.

## README Quick Start rewritten

- macOS path: download `install.command` → double-click. Gatekeeper note inline.
- Linux path: download `install.sh` → `bash ~/Downloads/install.sh`.
- Login dance removed entirely; replaced with one bullet point: "Detects whether you're already logged in to Claude Code. If not, it opens the sign-in flow; the installer continues automatically once you finish."

## Out of scope

- Chrome Web Store submission. The user explicitly chose option **A** (just inline login + .command rename) over the bigger lift of Web Store publishing. Web Store would eliminate the unzip → Developer mode → Load unpacked steps, but costs a $5 dev account + ~3 day review per release.

## Test plan

- [x] CI green
- [ ] After merge: re-tag v0.2.1 (or re-tag v0.2.0 if user prefers a clean slate again) → release workflow attaches `install.sh`, `install.command`, `host.js`, extension zip
- [ ] Reviewer downloads `install.command` on macOS, double-clicks, completes the inline login when prompted, verifies the panel works