### PR TITLE
chore: bump version to v0.2.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkshit",
-  "version": "0.1.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkshit",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -16,7 +16,7 @@
         "web-ext": "^10.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
## Summary

Pure version bump. Picks up the inline-Claude-Code-login + macOS-double-click installer work from #15 as a tagged release.

| File | 0.2.0 → 0.2.1 |
|---|---|
| `manifest.json` | ✓ |
| `package.json` | ✓ |
| `package-lock.json` | ✓ (regenerated via `npm install --package-lock-only`) |

No code changes. Per the project's QA-skip convention for version-bump PRs, green CI is enough — no QA agent run needed.

## Test plan

- [ ] CI green
- [ ] After merge: `git tag v0.2.1 <merge-sha>` → release workflow ships the assets