### PR TITLE
docs: cleanup post-v0.2.1 stale doc refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,9 @@ The browser-side code never changes.
 |---|---|
 | Panel never appears | Extension not loaded, or you're on a non-`www` LinkedIn subdomain. Check `chrome://extensions`. Reload the LinkedIn tab. |
 | `captured` stuck at 0 | Selector drift. See Risks. |
-| `Error: native host disconnected before responding (is it installed?)` | Chrome can't find `host.js`. The native messaging manifest is missing, or its `path` is wrong. Re-check step 3 of Setup. |
+| `Error: native host disconnected before responding (is it installed?)` | Chrome can't find `host.js`. The native messaging manifest is missing or pointing at the wrong path. Re-run `install.sh` / `install.command`, or follow "Manual setup → 3. Register the native messaging host". |
 | `Error: failed to connect to native host: …` | Same family — manifest exists but Chrome rejected it. Often the `allowed_origins` doesn't list the right extension ID. Confirm the extension ID at `chrome://extensions` matches `pgcnimcldmdfkemofhjfnemieckciche`. |
-| `Error: claude exit …` | `claude` not in PATH or not logged in. Run `claude` manually first. |
+| `Error: claude exit …` | `claude` not in PATH or not logged in. Run `claude auth status` to check; `claude auth login` to fix the login. |
 | Quota exhausted mid-session | See Cost / quota. |
 | `Error: claude exit 1` with no stderr | Try `CLAUDE_MODEL=sonnet` — `haiku` may not be available on your plan. Edit `~/.linkshit/host.js` and set `MODEL` accordingly, or wrap `host.js` in a tiny script that exports the env var before exec'ing the real one. |
 

--- a/installers/install.sh
+++ b/installers/install.sh
@@ -161,8 +161,9 @@ if [ "${#LINKSHIT_HOST_JS_BASE64}" -lt 200 ]; then
 ERROR: failed to download host.js from ${URL}.
 
 If no release exists yet, this is expected — please use the released
-install.sh from the Releases page instead, which embeds host.js inline
-and needs no network. https://github.com/Replikanti/linkshit/releases
+installer from the Releases page (\`install.sh\` on Linux,
+\`install.command\` on macOS), which embeds host.js inline and needs
+no network. https://github.com/Replikanti/linkshit/releases
 EOF
     exit 1
   fi


### PR DESCRIPTION
## Summary

Three small doc fixes the user spotted after v0.2.1 shipped — none of them user-blocking but all of them point at the pre-inline-login behaviour and would mislead a confused reader.

| Where | Was | Now |
|---|---|---|
| `README.md` Troubleshooting `Error: claude exit …` | "Run `claude` manually first." | "Run `claude auth status` to check; `claude auth login` to fix the login." |
| `README.md` Troubleshooting native-host disconnect | "Re-check step 3 of Setup." (ambiguous — Quick Start and Manual setup both have a step 3 now) | "Re-run `install.sh` / `install.command`, or follow Manual setup → 3. Register the native messaging host." |
| `installers/install.sh` fallback error when host.js download fails | "please use the released install.sh from the Releases page" | "please use the released installer from the Releases page (`install.sh` on Linux, `install.command` on macOS)" |

Docs-only, no behaviour changes. Per the project's version-bump/docs exception, green CI = merge — no QA agent run needed.

## Test plan

- [ ] CI green