### PR TITLE
feat: Cancel button in Settings drawer

### DIFF
--- a/content.js
+++ b/content.js
@@ -324,6 +324,7 @@
         <label>Batch size</label><input id="s-batchSize" type="number"/>
         <label>Max posts per session</label><input id="s-maxPosts" type="number"/>
         <button id="s-save" class="primary">Save</button>
+        <button id="s-cancel">Cancel</button>
         <button id="s-clear">Clear DB</button>
       </div>`;
     document.body.append(panel);
@@ -364,6 +365,11 @@
       SAVE('maxPosts', Number.parseInt($('s-maxPosts').value, 10) || 1500);
       $('lks-settings').style.display = 'none';
       setStatus('Settings saved.');
+    };
+    $('s-cancel').onclick = () => {
+      sync();
+      $('lks-settings').style.display = 'none';
+      setStatus('Settings unchanged.');
     };
     $('s-clear').onclick = async () => {
       if (!confirm('Wipe all stored posts and scores?')) return;


### PR DESCRIPTION
## Summary

- Adds a \`Cancel\` button between \`Save\` and \`Clear DB\` in the Settings (⚙) drawer.
- Click reverts all inputs to the currently-saved \`CFG\` values via the existing \`sync()\` function and closes the drawer. No persistence side-effect.

Closes #22.

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` — clean
- [ ] CI green
- [ ] Code-level QA: \`Cancel\` calls \`sync()\` (reads CFG into inputs) then hides drawer; no \`SAVE()\` called.