### PR TITLE
feat: detect Claude quota exhaustion and auto-pause

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,9 @@ CI (`ci.yml`) runs check / validate / lint / pack on every push and PR. Extras
 native-host smoke test. CodeQL runs separately.
 
 There is no test runner / framework. The smoke test in `scripts/smoke-host.js`
-**is** the host's test suite — four assertions over the native messaging
-plumbing. Add cases there when you change `host.js`.
+**is** the host's test suite — five assertions over the native messaging
+plumbing (happy path, unknown type, missing posts, malformed JSON, and
+quota-exhausted classification). Add cases there when you change `host.js`.
 
 ## Build / pack
 

--- a/content.js
+++ b/content.js
@@ -247,7 +247,9 @@
       posts,
     });
     if (!response?.ok) {
-      throw new Error(response?.error || 'no response from native host');
+      const err = new Error(response?.error || 'no response from native host');
+      err.code = response?.code;
+      throw err;
     }
     const arr = response.result;
     if (!Array.isArray(arr)) {
@@ -265,7 +267,13 @@
   // already in flight, we still want to drain the remainder once the batch
   // completes — even if it's smaller than batchSize.
   let pendingForce = false;
+  // Set when the host returns code='quota_exhausted'. Blocks further flushes
+  // until the user clicks Resume (startScroll clears the flag) — without it,
+  // the auto re-flush at the end of maybeFlush would immediately retry and
+  // burn the next request against the still-exhausted limit.
+  let quotaPaused = false;
   async function maybeFlush(force = false) {
+    if (quotaPaused) return;
     if (force) pendingForce = true;
     if (scoring || queue.length === 0) return;
     if (queue.length < CFG.batchSize && !pendingForce) return;
@@ -286,13 +294,19 @@
       ui.setStatus(scrollTimer ? 'Scrolling…' : 'Idle.');
     } catch (e) {
       console.error('[Linkshit]', e);
-      ui.setStatus('Error: ' + e.message);
       for (const p of batch) queue.unshift(p);
-      await sleep(15000);
+      if (e.code === 'quota_exhausted') {
+        quotaPaused = true;
+        pauseScroll();
+        ui.setStatus('Quota hit; click Resume to retry.');
+      } else {
+        ui.setStatus('Error: ' + e.message);
+        await sleep(15000);
+      }
     } finally {
       scoring = false;
       if (queue.length === 0) pendingForce = false;
-      if (queue.length >= CFG.batchSize || (pendingForce && queue.length > 0)) {
+      if (!quotaPaused && (queue.length >= CFG.batchSize || (pendingForce && queue.length > 0))) {
         maybeFlush();
       }
     }
@@ -399,6 +413,13 @@
     // session as a whole still respects the cap; a fresh start resets it.
     if (!paused) postsAtStart = seen.size;
     paused = false;
+    // Manual Start / Resume always retries scoring after a quota stall —
+    // the user clicking the button is the explicit "try again" signal.
+    if (quotaPaused) {
+      quotaPaused = false;
+      // Drain any queue that piled up while quota-paused.
+      maybeFlush();
+    }
     const tick = () => {
       if (!scrollTimer) return;
       window.scrollTo(0, document.body.scrollHeight);

--- a/host.js
+++ b/host.js
@@ -96,6 +96,15 @@ POSTS:
 ${list}`;
 }
 
+// Patterns observed in claude CLI / Anthropic API errors when the user's
+// usage-window or rate limit is exhausted. Match conservatively — false
+// positives only mean the panel shows a "Quota hit" status instead of a
+// generic error, which is still informative.
+const QUOTA_PATTERN = /rate.?limit|quota|usage limit|5.?hour limit|429|too many requests/i;
+function classifyClaudeError(stderr) {
+  return QUOTA_PATTERN.test(stderr || '') ? 'quota_exhausted' : null;
+}
+
 // Swap point. Replace this body to use a different LLM backend.
 function runLLM(prompt) {
   return new Promise((resolve, reject) => {
@@ -107,9 +116,17 @@ function runLLM(prompt) {
     proc.stdout.on('data', c => { out += c; });
     proc.stderr.on('data', c => { err += c; });
     proc.on('error', reject);
-    proc.on('close', code =>
-      code === 0 ? resolve(out) : reject(new Error(err.trim() || `claude exit ${code}`))
-    );
+    proc.on('close', code => {
+      if (code === 0) {
+        resolve(out);
+        return;
+      }
+      const e = new Error(err.trim() || `claude exit ${code}`);
+      e.classification = classifyClaudeError(err);
+      e.exitCode = code;
+      e.stderr = err.trim();
+      reject(e);
+    });
   });
 }
 
@@ -140,7 +157,9 @@ async function handle(msg) {
     const arr = parseJsonArray(out);
     return { ok: true, result: arr };
   } catch (e) {
-    return { ok: false, error: e.message };
+    const env = { ok: false, error: e.message };
+    if (e.classification) env.code = e.classification;
+    return env;
   }
 }
 

--- a/scripts/smoke-host.js
+++ b/scripts/smoke-host.js
@@ -5,13 +5,15 @@
 // from its stdout. Stubs `claude` so the test doesn't depend on the user
 // being logged in to Claude Code or having network access.
 //
-// Asserts the four behaviors of the native messaging plumbing that we
+// Asserts the five behaviors of the native messaging plumbing that we
 // most want to keep working:
 //   1. happy-path scoring round-trip
 //   2. unknown message type is reported via {ok:false,error}
 //   3. missing posts is reported via {ok:false,error}
 //   4. malformed JSON inside a frame is reported via {ok:false,error}
 //      (not silently dropped — the bug fixed during PR-A's QA round)
+//   5. quota-exhausted stderr from claude is classified as
+//      {ok:false,error,code:'quota_exhausted'} (covers issue #26)
 //
 // Runs in the `native host smoke test` job in extras.yml on every PR
 // and push to main, and locally via `npm run smoke`.
@@ -26,11 +28,27 @@ const HOST_PATH = path.resolve(__dirname, '..', 'host.js');
 // Atomically create a temp dir owned only by us, then drop a stub `claude`
 // inside. Avoids the TOCTOU pitfall flagged by CodeQL on the previous
 // smoke script (which used a predictable os.tmpdir() + pid path).
+//
+// Counter-based stub so a single host process can drive both the happy-path
+// (call #1) and the quota-exhausted path (call #2). Cases that don't reach
+// runLLM (unknown type / missing posts / malformed JSON) don't advance the
+// counter — they short-circuit before claude is spawned.
 const stubDir = fs.mkdtempSync(path.join(os.tmpdir(), 'linkshit-host-smoke-'));
 const stubPath = path.join(stubDir, 'claude');
+const counterPath = path.join(stubDir, 'counter');
 fs.writeFileSync(
   stubPath,
-  '#!/bin/bash\necho \'[{"id":1,"score":7,"reason":"stub-ok"}]\'\n',
+  '#!/bin/bash\n'
+  + `COUNTER='${counterPath}'\n`
+  + 'COUNT=$(cat "$COUNTER" 2>/dev/null || echo 0)\n'
+  + 'COUNT=$((COUNT + 1))\n'
+  + 'echo "$COUNT" > "$COUNTER"\n'
+  + 'if [ "$COUNT" = "1" ]; then\n'
+  + '  echo \'[{"id":1,"score":7,"reason":"stub-ok"}]\'\n'
+  + 'else\n'
+  + '  echo "Error: rate limit exceeded — try again in a few hours" >&2\n'
+  + '  exit 1\n'
+  + 'fi\n',
   { mode: 0o755 },
 );
 
@@ -128,7 +146,18 @@ async function checks() {
     fail(`malformed-json: expected error envelope, got ${JSON.stringify(r4)}`);
   }
 
-  console.log('SMOKE OK: 4/4 assertions passed');
+  // 5. quota-exhausted stderr is classified
+  sendFrame({
+    type: 'score',
+    criteria: 'smoke',
+    posts: [{ author: 'B', text: 'second batch second batch second batch', reactions: 0 }],
+  });
+  const r5 = await readFrame();
+  if (r5.ok || r5.code !== 'quota_exhausted' || !r5.error?.includes('rate limit')) {
+    fail(`quota-classification: expected {ok:false,code:'quota_exhausted',error:/rate limit/}, got ${JSON.stringify(r5)}`);
+  }
+
+  console.log('SMOKE OK: 5/5 assertions passed');
   cleanup();
   process.exit(0);
 }


### PR DESCRIPTION
## Summary

- \`host.js\`: \`classifyClaudeError(stderr)\` matches common rate-limit / quota patterns. \`runLLM\` decorates rejections with \`classification\` / \`exitCode\` / \`stderr\`. Handler responds with \`{ ok: false, error, code: 'quota_exhausted' }\` (additive \`code\` field — legacy consumers keep reading \`error\`).
- \`content.js\`: new \`quotaPaused\` flag, \`maybeFlush\` catch branch returns batch to queue + calls \`pauseScroll\`. Start / Resume clears the flag and drains.
- \`scripts/smoke-host.js\`: counter-based stub claude (happy on call #1, quota error on call #2) + new 5th assertion. Existing 4 unchanged.
- \`CLAUDE.md\`: smoke-test count bumped 4 → 5.

Closes #26.

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` — clean
- [x] \`npm run smoke\` — \`SMOKE OK: 5/5 assertions passed\` locally
- [ ] CI green
- [ ] Code-level QA: backwards-compatible envelope; no infinite-retry loop (\`quotaPaused\` short-circuits both the entry guard and the auto-reflush at the end of \`maybeFlush\`); batch is restored to queue front before pausing.

## Notes

- \`retryAfter\` field omitted — Claude CLI doesn't surface a structured retry-after, so honest defaults to "user-clicks-Resume" rather than guessing.
- Pattern is intentionally broad (\`/rate.?limit|quota|usage limit|5.?hour limit|429|too many requests/i\`) — false positives only swap the status text from generic-error to quota-error, which is still useful.