### PR TITLE
chore: bump version to v0.3.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkshit",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkshit",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Bump \`package.json\` / \`manifest.json\` / \`package-lock.json\` from \`0.2.1\` → \`0.3.0\`.

## What's new since v0.2.1

**Functionality**
- Skip Promoted / sponsored posts (#19)
- \`Max age (hours)\` time-based pre-filter (#25)
- Named criteria profiles + header switcher (#27)
- Rescore stored posts against current criteria (#24)
- Persist queued posts across tab close (#29)
- Auto-pause on Claude quota exhaustion + smoke test 5/5 (#26)

**UX / UI**
- Empty-state onboarding hint (#23)
- Settings Cancel button (#22)
- Dark mode via \`prefers-color-scheme\` (#20)
- Pause / Resume preserving the queue (#21)
- Resizable / movable panel with persisted geometry (#30)
- Borderline-score toggle (#31)
- History view of all-time scored posts (#28)

## Verification

- [x] \`npm run check\` / \`validate\` / \`lint\` — clean
- [x] \`npm run pack\` — produces \`linkshit-0.3.0.zip\`
- [x] \`npm run smoke\` — 5/5 assertions passed
- [ ] CI green

Per CLAUDE.md: metadata-only PR, QA pass skipped — green CI is enough. Tag will be pushed immediately on merge to trigger \`release.yml\`.