### PR TITLE
fix: hide profile selector until 2+ profiles exist

### DIFF
--- a/content.js
+++ b/content.js
@@ -546,7 +546,7 @@
     panel.innerHTML = `
       <div id="lks-resize"></div>
       <header>
-        <span>Linkshit · <select id="lks-profile" title="Active profile"></select></span>
+        <span>Linkshit<span id="lks-profile-wrap" style="display:none"> · Profile: <select id="lks-profile" title="Active profile"></select></span></span>
         <span>
           <button id="lks-start" class="primary">Start</button>
           <button id="lks-pause">Pause</button>
@@ -682,6 +682,11 @@
         if (p.name === profiles.activeName) opt.selected = true;
         sel.append(opt);
       }
+      // Hide the whole "· Profile: [select]" affordance when a single profile
+      // exists — at that point the dropdown is just a confusing title-suffix
+      // with one inert option. It pops back the moment the user creates a
+      // second profile in ⚙.
+      $('lks-profile-wrap').style.display = profiles.list.length > 1 ? '' : 'none';
     }
     refreshProfileSelector();
 


### PR DESCRIPTION
## Summary

- Wraps the header profile \`<select>\` in a span (\`#lks-profile-wrap\`) that defaults to \`display:none\` and includes a new \`Profile:\` label.
- \`refreshProfileSelector()\` toggles the wrap based on \`profiles.list.length > 1\`. Single source of truth — already called on load + every profile-mutating action.
- Header reads \`Linkshit\` for fresh users; flips to \`Linkshit · Profile: [select]\` once a second profile is created in ⚙.

Closes #46.

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` — clean
- [x] \`npm run smoke\` — 5/5
- [ ] CI green
- [ ] Code-level QA: wrap visibility computed in one place, no other code paths can leave the dropdown visible with a single profile.