### PR TITLE
fix(manifest): drop background.scripts (MV2-only)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,6 @@
   "permissions": ["nativeMessaging"],
   "background": {
     "service_worker": "background.js",
-    "scripts": ["background.js"],
     "type": "module"
   },
   "content_scripts": [


### PR DESCRIPTION
Removes the legacy \`background.scripts\` key. \`service_worker\` + \`type: \"module\"\` stay — both valid in MV3.

Closes #49.

## Verification

- [x] \`npm run check\` / \`validate\` / \`lint\` / \`pack\` — clean
- [ ] CI green
- [ ] Code-level QA: only the one key dropped; service worker still pointed at \`background.js\`.