### PR TITLE
chore: bump version to v0.3.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linkshit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "linkshit",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Patch release: LinkedIn 2026-05 DOM rewrite recovery (#51 / #52). Without this, \`captured\` stays at 0 on every session.

## Verification

- [x] \`npm run check\` / \`validate\` / \`lint\` / \`smoke\` — clean
- [x] \`npm run pack\` — produces \`linkshit-0.3.2.zip\`
- [ ] CI green