### PR TITLE
fix: extract real author and observe whole feed subtree

### DIFF
--- a/content.js
+++ b/content.js
@@ -221,14 +221,33 @@
     }
     return null;
   }
+  // Walk up from a post-text element to the smallest ancestor that also
+  // contains an author link — that is the post wrapper. Stops at feed
+  // itself so we never escape into the page chrome. Used by capture to
+  // turn each [data-testid="expandable-text-box"] into a wrapper that
+  // extractPost / isPromoted / extractAgeHours all operate on.
+  function findWrapper(textBox, feed) {
+    let n = textBox.parentElement;
+    while (n && n !== feed) {
+      if (n.querySelector(AUTHOR_SEL)) return n;
+      n = n.parentElement;
+    }
+    return null;
+  }
   function extractPost(el) {
     const textEl = el.querySelector(POST_TEXT_SEL);
     if (!textEl) return null;
-    const authorLink = el.querySelector(AUTHOR_SEL);
+    // Each post carries ~2 author links: an avatar wrapper around an
+    // <img> (first in DOM order, empty innerText) and the name link.
+    // Pick the first link whose innerText has a non-empty first line so
+    // the avatar wrapper does not poison the author field.
+    let authorLink = null, authorRaw = null;
+    for (const a of el.querySelectorAll(AUTHOR_SEL)) {
+      const raw = (a.innerText || '').split('\n').map(l => l.trim()).filter(Boolean);
+      if (raw[0]) { authorLink = a; authorRaw = raw; break; }
+    }
     if (!authorLink) return null;
-    const authorRaw = (authorLink.innerText || '').split('\n').map(l => l.trim()).filter(Boolean);
     const author = authorRaw[0];
-    if (!author) return null;
     const text = (textEl.innerText || '').trim();
     if (!text || text.length < 30) return null;
     const subtitle = authorRaw.slice(1).join(' · ').slice(0, 200);
@@ -420,21 +439,32 @@
   }
   function startObserver() {
     // The feed list is rendered lazily by LinkedIn's React shell, often
-    // after document_idle. Poll for it; once mounted, observe its direct
-    // children (each post wrapper is one child of [data-testid="mainFeed"])
-    // and seed with whatever children are already there.
+    // after document_idle. Post wrappers in the 2026-05 DOM are not
+    // direct children of [data-testid="mainFeed"] — text-boxes sit ~8
+    // levels deep inside a handful of section wrappers. Observing only
+    // childList on feed therefore misses every lazy-mount below. Watch
+    // the whole subtree and rescan over [data-testid="expandable-text-box"]
+    // on each batch; the djb2 urn dedup makes rescans cheap and idempotent.
     const attach = () => {
       const feed = document.querySelector(FEED_SEL);
       if (!feed) {
         setTimeout(attach, 1000);
         return;
       }
-      new MutationObserver(muts => {
-        for (const m of muts) for (const n of m.addedNodes) {
-          if (n.nodeType === 1) tryCapture(n);
+      let pending = false;
+      const rescan = () => {
+        pending = false;
+        for (const tb of feed.querySelectorAll(POST_TEXT_SEL)) {
+          const wrapper = findWrapper(tb, feed);
+          if (wrapper) tryCapture(wrapper);
         }
-      }).observe(feed, { childList: true });
-      for (const child of feed.children) tryCapture(child);
+      };
+      new MutationObserver(() => {
+        if (pending) return;
+        pending = true;
+        setTimeout(rescan, 150);
+      }).observe(feed, { childList: true, subtree: true });
+      rescan();
     };
     attach();
   }


### PR DESCRIPTION
Two regressions from PR #52 that only surfaced once a maintainer ran v0.3.2 against real `linkedin.com/feed/`. Closes #54.

## Bug 1 — `extractPost` returned null for every post

`AUTHOR_SEL = 'a[href*="/in/"], a[href*="/company/"]'` matches both the avatar `<a>` (wraps `<img>`, empty `innerText`) and the name link. `el.querySelector(AUTHOR_SEL)` returns the first match in DOM order — the avatar — so `authorRaw[0]` was always `undefined` and the function exited at `if (!author) return null`. `captured` stayed pinned at 0.

Fix: iterate `el.querySelectorAll(AUTHOR_SEL)` and take the first link whose `innerText` has a non-empty first line.

## Bug 2 — observer missed every lazy-mounted post

PR #52 said *"observes only its direct children"* and the seed loop walked `feed.children`. The live DOM has **12 direct children** with **71 posts nested ~8 levels deep**. Even after Bug 1 is fixed, `{ childList: true }` on `feed` only fires when one of those 12 wrappers is added/removed; lazy-mounts inside an existing wrapper are silent.

Fix: switch to `{ childList: true, subtree: true }` and on each debounced (150 ms) batch rescan `feed.querySelectorAll(POST_TEXT_SEL)`, walking up from each text-box via the new `findWrapper(textBox, feed)` helper. The existing djb2 urn dedup makes rescans cheap and idempotent.

## Diagnostic data

```js
({
  feed: 1,
  postsInsideFeed: 71,
  authors: 160,                  // ~2.25 per post — avatar + name
  directChildren: 12,
  firstPostDepthFromFeed: 8,
})
// On a real wrapper, first AUTHOR_SEL match:
({ authorContainsImg: true, authorInnerText: '""' })
```

## Test plan

- [x] `npm run check` / `validate` / `lint` / `smoke` — clean, smoke 5/5
- [ ] CI green
- [ ] Live exercise on `linkedin.com/feed/`: `captured` jumps within seconds of mount; with default criteria, `queued` and `scored` follow
- [ ] Regression: sponsored posts still register as `promoted` (path unchanged, exercised via the new wrapper)