### PR TITLE
chore: bump version to v0.3.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Release bump for the observer survival fix shipped in #58.

## What's in v0.3.4

- **#58** — \`fix: observe document.body to survive LinkedIn feed re-mounts\`. Closes #57. v0.3.3 attached the MutationObserver to \`[data-testid=\"mainFeed\"]\`, which dies when LinkedIn React re-mounts the feed wrapper. Also \`tryCapture\` swallowed async \`dbGet\` rejections, freezing the captured counter for any urn that triggered one. Fix: observe \`document.body\` (re-query feed each rescan), wrap \`tryCapture\` in try/catch with a single \`console.warn\`. Live verified.

Touches \`package.json\` and \`manifest.json\` only.