### PR TITLE
fix: scroll <main> instead of document.body for infinite-feed loop

### DIFF
--- a/content.js
+++ b/content.js
@@ -490,16 +490,24 @@
     }
     const tick = () => {
       if (!scrollTimer) return;
-      window.scrollTo(0, document.body.scrollHeight);
+      // The 2026-05 React rewrite moved scroll out of document.body into a
+      // flex-grow <main>; window.scrollTo / body.scrollHeight are no-ops on
+      // that DOM and the height-stable check trips after the initial render.
+      // Resolve the real container per tick (cheap, survives <main>
+      // re-mount) and fall back to the document scroller / body so older
+      // or future LinkedIn variants that scroll the document still work.
+      const scroller = document.querySelector('main') || document.scrollingElement || document.body;
+      scroller.scrollTo(0, scroller.scrollHeight);
       document.querySelectorAll('button').forEach(b => {
         const t = (b.innerText || '').toLowerCase();
         if (t.includes('load more comment') || t.includes('show more replies')
          || t.includes('zobrazit další') || t.includes('načíst předchozí')) b.click();
       });
-      if (document.body.scrollHeight === lastH) {
+      const h = scroller.scrollHeight;
+      if (h === lastH) {
         if (++stable > 6) { stopScroll(); ui.setStatus('End of feed.'); maybeFlush(true); return; }
       } else {
-        stable = 0; lastH = document.body.scrollHeight;
+        stable = 0; lastH = h;
       }
       if (seen.size - postsAtStart >= CFG.maxPosts) {
         stopScroll(); ui.setStatus(`maxPosts=${CFG.maxPosts} reached.`); maybeFlush(true); return;


### PR DESCRIPTION
The 2026-05 React rewrite moved scroll out of \`document.body\` into a flex-grow \`<main>\`. The auto-scroller's \`window.scrollTo(0, body.scrollHeight)\` is a no-op on that DOM and the height-stable end-detection trips on the constant \`body.scrollHeight\` — \`captured\` plateaus at the initial render (~21 posts) and the panel reports \"End of feed.\" within seconds of clicking Start. Closes #60.

## Diagnosis

Run on real \`linkedin.com/feed/\`:

\`\`\`js
({ before: document.body.scrollHeight,
   after:  (window.scrollTo(0, document.body.scrollHeight), document.body.scrollHeight) })
// → { before: 927, after: 927 }
\`\`\`

927 px ≈ viewport. The actual scrollable element:

\`\`\`
{ tag: 'MAIN', scrollH: 24736, clientH: 875 }   // ~28x viewport, the real feed
\`\`\`

## Fix

Resolve the scroll container per tick:

\`\`\`js
const scroller = document.querySelector('main') || document.scrollingElement || document.body;
scroller.scrollTo(0, scroller.scrollHeight);
// ...
if (scroller.scrollHeight === lastH) { ... } else { lastH = scroller.scrollHeight; ... }
\`\`\`

Re-resolving each tick is one selector match and survives React re-mount of \`<main>\`. The fallback chain keeps the old behaviour on any LinkedIn variant that scrolls the document.

\`lastH\` initialization at \`let lastH = 0\` stays — first tick reads the real height, sets stable=0, loop continues.

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` / \`smoke\` — clean, smoke 5/5
- [ ] CI green
- [ ] Live exercise on \`linkedin.com/feed/\`: click Start, expect \`captured\` to keep climbing well past the initial render. \"End of feed.\" should fire only after \`<main>\` truly stops growing (typically minutes).
- Regression: pause / resume, maxPosts cap, panel state machine — paths unchanged.