### PR TITLE
fix: scored counter accounts for previously-scored re-encounters

### DIFF
--- a/content.js
+++ b/content.js
@@ -422,6 +422,10 @@
       }
       const ex = await dbGet(post.urn);
       if (ex?.status === 'scored') {
+        // Re-encountering a post the LLM already scored in a previous
+        // session counts toward `scored` so the panel invariant
+        // hits ≤ scored holds across reloads.
+        ui.bump('scored', 1);
         if (ex.score >= CFG.scoreThresh) ui.addResult(ex);
         else if (CFG.showBorderline && ex.score >= CFG.scoreThresh - CFG.borderlineDelta) {
           ui.addResult({ ...ex, borderline: true });
@@ -998,6 +1002,9 @@
       : CFG.scoreThresh;
     const past = await dbAllScored(lowerBound);
     for (const p of past.slice(0, 50)) {
+      // Bump `scored` for each past hit we surface so the panel invariant
+      // hits ≤ scored holds at boot before any fresh scoring runs.
+      ui.bump('scored', 1);
       ui.addResult(p.score >= CFG.scoreThresh ? p : { ...p, borderline: true });
     }
     const anyStored = await dbAllScored(0);


### PR DESCRIPTION
The \`scored\` counter only advanced after a fresh LLM batch returned. Two paths that surface previously-stored hits — the boot history-render loop and \`tryCapture\`'s \`ex?.status === 'scored'\` branch — render results via \`ui.addResult\` (which bumps \`hits\`) without ever bumping \`scored\`.

Maintainer reading: \`captured 228, queued 77, scored 0, hits 3\` — three boot-rendered hits, zero LLM batches yet, counter stuck at 0. Violates the obvious invariant \`hits ≤ scored\`.

Closes #63 — Symptom B only. Symptom A (tab crash near captured ~230) stays open and needs a Performance-tab capture before any fix.

## Fix

\`content.js\` only.

\`\`\`diff
-    const past = await dbAllScored(lowerBound);
-    for (const p of past.slice(0, 50)) {
-      ui.addResult(p.score >= CFG.scoreThresh ? p : { ...p, borderline: true });
-    }
+    const past = await dbAllScored(lowerBound);
+    for (const p of past.slice(0, 50)) {
+      ui.bump('scored', 1);
+      ui.addResult(p.score >= CFG.scoreThresh ? p : { ...p, borderline: true });
+    }
\`\`\`

\`\`\`diff
       const ex = await dbGet(post.urn);
       if (ex?.status === 'scored') {
+        ui.bump('scored', 1);
         if (ex.score >= CFG.scoreThresh) ui.addResult(ex);
         else if (CFG.showBorderline && ex.score >= CFG.scoreThresh - CFG.borderlineDelta) {
           ui.addResult({ ...ex, borderline: true });
         }
         return;
       }
\`\`\`

Re-encounter bump fires regardless of whether the re-encountered score crosses the threshold — it still counts as a post we have a score for. \`maybeFlush\` and rescore continue to bump \`scored\` by \`scored.length\` per LLM batch; those paths are unchanged.

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` / \`smoke\` — clean, smoke 5/5
- [ ] CI green
- [ ] Live: open the tab on \`linkedin.com/feed/\` with stored hits in IDB. Boot should bump \`scored\` to match \`hits\` immediately. After scrolling, \`scored\` should advance for both fresh batches and re-encountered previously-scored posts.

Out of scope: any change to the math definition of \`captured\` / \`queued\` / \`promoted\`. Tooltip / labeling work for the counter row is bundled into the broader UX ticket.