### PR TITLE
fix: scope MutationObserver to <main> to reduce mutation traffic

### DIFF
--- a/content.js
+++ b/content.js
@@ -450,14 +450,39 @@
     // The feed list is rendered lazily by LinkedIn's React shell. Two earlier
     // attempts (subtree on the feed wrapper) failed in production: LinkedIn
     // periodically re-mounts the feed element, which leaves any observer
-    // bound to the old node detached and silent. We watch document.body
-    // instead — it outlives every feed re-render — and re-query the feed
-    // inside the debounced rescan so a fresh wrapper is picked up
-    // automatically. The 250 ms debounce + djb2 urn dedup keep the cost
-    // bounded even though body mutates on every LinkedIn UI tick.
+    // bound to the old node detached and silent.
+    //
+    // PR #58 worked around that by observing document.body subtree:true.
+    // That caught everything but is the suspected cause of long-session
+    // tab crashes (#63 Symptom A) — body subtree fires on every animation,
+    // hover, video buffer, and unrelated React update across the whole
+    // page, allocating MutationRecord arrays at browser-tick rate.
+    //
+    // <main> is the document layout container, sits above the React app,
+    // and outlives feed re-mounts. Subtree observation rooted at <main>
+    // still catches every text-box mount that PR #58 needed but ignores
+    // header / left rail / chat panel / video chrome traffic.
+    //
+    // Defensive: if we ever observe an element that gets detached from
+    // the document (rare but possible), the next rescan re-attaches.
+    // Falls back to document.body when <main> is not yet present so the
+    // first paint window still works.
     let pending = false;
+    let observed = null;
+    let observer = null;
     const rescan = () => {
       pending = false;
+      const root = document.querySelector('main') || document.body;
+      if (root !== observed || (observed && !document.contains(observed))) {
+        if (observer) observer.disconnect();
+        observed = root;
+        observer = new MutationObserver(() => {
+          if (pending) return;
+          pending = true;
+          setTimeout(rescan, 250);
+        });
+        observer.observe(observed, { childList: true, subtree: true });
+      }
       const feed = document.querySelector(FEED_SEL);
       if (!feed) return;
       for (const tb of feed.querySelectorAll(POST_TEXT_SEL)) {
@@ -465,11 +490,6 @@
         if (wrapper) tryCapture(wrapper);
       }
     };
-    new MutationObserver(() => {
-      if (pending) return;
-      pending = true;
-      setTimeout(rescan, 250);
-    }).observe(document.body, { childList: true, subtree: true });
     rescan();
   }
 


### PR DESCRIPTION
PR #58 observed \`document.body\` with subtree:true to survive React re-mounts of the feed wrapper — correct as a survivability fix, but turned the MO callback into a hot path: every animation, hover state change, video buffer tick, and unrelated React update across the whole page allocates a MutationRecord array. Suspected cause of #63 Symptom A (tab crash near captured ~230, now reproduced twice).

This scopes observation root to \`<main>\` — the document layout container, sits above the React app, outlives feed re-mounts (the failure mode #58 worked around). Every text-box mount that #58 needs to catch happens inside \`<main>\`. Header, left rail, chat panel, video chrome, and footer mutations no longer trigger the rescan debounce. Order-of-magnitude or more reduction in MO callback fire rate is plausible on a busy LinkedIn page.

Mitigates #63 (Symptom A). Does NOT address #63 Symptom B — that's PR #65.

## Defensive details

- Re-attach loop: each rescan re-resolves \`document.querySelector('main') || document.body\` and disconnects + re-attaches the observer if the root changed (never expected once \`<main>\` is up, but cheap belt-and-suspenders).
- Detached-element self-heal: \`!document.contains(observed)\` triggers re-attach. If LinkedIn ever does re-mount \`<main>\` itself, we recover.
- Fallback to \`document.body\` during the first-paint window before \`<main>\` exists.

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` / \`smoke\` — clean, smoke 5/5
- [ ] CI green
- [ ] Live: maintainer runs an extended session — multiple hundred captured, scoring active. Crash should not reoccur.
- Regression: capture pipeline / scroll loop / panel state machine / re-encounter dedup all unchanged paths.

If a Performance-tab capture from a future crash becomes available before merge, we can verify the hypothesis directly. Otherwise this ships behind the same review pattern.