### PR TITLE
chore: bump version to v0.3.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Release bump for the scored counter and observer scope fixes shipped in #65 and #66.

## What's in v0.3.6

- **#65** — \`fix: scored counter accounts for previously-scored re-encounters\`. Closes #63 Symptom B. The \`scored\` counter only advanced after fresh LLM batches; boot history-render and \`tryCapture\`'s \`previously scored\` branch surfaced hits without bumping it. Now \`hits ≤ scored\` holds across all paths.
- **#66** — \`fix: scope MutationObserver to <main> to reduce mutation traffic\`. Mitigates #63 Symptom A (long-session tab crash). Observer scope narrowed from \`document.body\` (which fires on every animation, hover, video buffer, unrelated React update across the whole page) to \`<main>\`, which sits above the React app, outlives feed re-mounts, and contains every text-box mount the capture pipeline cares about.

Touches \`package.json\` and \`manifest.json\` only.