### PR TITLE
fix: mark processed text-boxes in rescan to bound async fan-out

### DIFF
--- a/content.js
+++ b/content.js
@@ -471,6 +471,20 @@
     // the document (rare but possible), the next rescan re-attaches.
     // Falls back to document.body when <main> is not yet present so the
     // first paint window still works.
+    // Marker-based fast-skip on text-box nodes. Without this the rescan
+    // re-runs extractPost / isPromoted (each a querySelectorAll) for every
+    // visible post on every tick — ~30-50 wrappers × ~3 rescans/sec = 90-150
+    // parallel async tryCapture invocations/sec, each allocating a Promise
+    // and an IDB transaction. Suspected cause of #63 Symptom A (tab crash
+    // around captured ~230 even after the <main>-scoped observer in #66).
+    //
+    // Stamping the text-box element itself means LinkedIn's virtualization
+    // (it unmounts off-screen posts and remounts new ones) automatically
+    // resets the marker for any genuinely new node. urn-based dedup in
+    // tryCapture stays as the second line of defense for the same post text
+    // re-mounted under a different DOM node.
+    const RESCAN_MARK = '__lksRescanProcessed';
+    const DEBOUNCE_MS = 500;
     let pending = false;
     let observed = null;
     let observer = null;
@@ -483,13 +497,15 @@
         observer = new MutationObserver(() => {
           if (pending) return;
           pending = true;
-          setTimeout(rescan, 250);
+          setTimeout(rescan, DEBOUNCE_MS);
         });
         observer.observe(observed, { childList: true, subtree: true });
       }
       const feed = document.querySelector(FEED_SEL);
       if (!feed) return;
       for (const tb of feed.querySelectorAll(POST_TEXT_SEL)) {
+        if (tb[RESCAN_MARK]) continue;
+        tb[RESCAN_MARK] = true;
         const wrapper = findWrapper(tb, feed);
         if (wrapper) tryCapture(wrapper);
       }


### PR DESCRIPTION
Second-line mitigation for #63 Symptom A. PR #66 narrowed the observer scope; the crash near captured ~230 still reproduced. The remaining hot spot is the rescan body itself, not the observer fire rate.

## Hypothesis

\`startObserver\`'s rescan iterates every \`expandable-text-box\` currently in the feed and calls \`tryCapture(wrapper)\` per element, no awaits, no skip for previously-walked nodes. With ~30-50 visible wrappers and a 250 ms debounce, that's ~90-150 parallel async invocations per second. Each:

- runs \`extractPost\` (DOM walk + multiple \`querySelectorAll\`)
- runs \`isPromoted\` (\`querySelectorAll('span, div')\` over the wrapper)
- awaits \`dbGet\` (separate IDB transaction)
- allocates a Promise frame regardless of whether dedup wins

The \`seen\` Set short-circuits only AFTER \`extractPost\` runs. So even posts the previous rescan already saw re-do the expensive extraction work.

## Fix

Stamp the text-box element itself the first time we walk it:

\`\`\`js
const RESCAN_MARK = '__lksRescanProcessed';
for (const tb of feed.querySelectorAll(POST_TEXT_SEL)) {
  if (tb[RESCAN_MARK]) continue;
  tb[RESCAN_MARK] = true;
  const wrapper = findWrapper(tb, feed);
  if (wrapper) tryCapture(wrapper);
}
\`\`\`

LinkedIn's virtualization unmounts off-screen posts and remounts new ones from scratch — the new DOM node has no marker, so the rescan picks it up exactly once. URN-based dedup in \`tryCapture\` stays as a second line of defense for the rare case where the same post text appears under a different DOM node within one session.

Also bumped the debounce from 250 ms to 500 ms — halves the baseline rescan rate independent of the marker work, and the marker check on already-processed text-boxes is now O(1) so a slightly later rescan is fine.

## Effect

After first rescan: visible text-boxes are all marked. Subsequent rescans iterate the same set but exit immediately on the marker check, doing zero work. The only nodes that produce real work are newly-mounted ones — exactly what the observer was meant to catch.

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` / \`smoke\` — clean, smoke 5/5
- [ ] CI green
- [ ] Live exercise on real \`linkedin.com/feed/\` — extended session past the previous ~230 crash threshold. Maintainer confirms.

## Mitigates #63

Does NOT close #63 until live-confirmed. If the crash still recurs, next steps in #63 are: serialize tryCapture awaits; profile the actual hot path; consider DOM virtualization for the result panel.