### PR TITLE
chore: bump version to v0.3.7

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Release bump for the rescan marker-skip mitigation in #68.

## What's in v0.3.7

- **#68** — \`fix: mark processed text-boxes in rescan to bound async fan-out\`. Mitigation candidate for #63 Symptom A (long-session tab crash). After #66 narrowed the observer scope, the rescan body itself was the remaining hot path: every visible text-box was re-walked through extractPost / isPromoted / dbGet on every tick, fanning out 90-150 parallel async invocations per second. Marker-based fast-skip on text-box DOM nodes converts rescan to O(newly-mounted) instead of O(visible). Debounce also bumped 250 ms → 500 ms.

Touches \`package.json\` and \`manifest.json\` only.