### PR TITLE
fix: cap visible result cards at 200 to bound panel DOM growth

### DIFF
--- a/content.js
+++ b/content.js
@@ -996,11 +996,19 @@
       if (el) el.textContent = counters[name];
       if (name === 'hits' || name === 'scored') hideHint();
     }
+    // Cap visible result cards to bound panel DOM growth in long sessions.
+    // History view (dbAllScored) still surfaces everything stored. Insert
+    // order is score-descending; eviction drops the lowest-score card from
+    // the tail. seen.add prevents tryCapture from re-walking the urn within
+    // this session, so evicted posts only re-render via the boot history
+    // loop on a future page load.
+    const MAX_PANEL_RESULTS = 200;
     function addResult(post) {
       if (rendered.has(post.urn)) return;
       rendered.add(post.urn);
       if (!post.borderline) bump('hits', 1);
       const div = document.createElement('div');
+      div.dataset.urn = post.urn;
       div.className = post.borderline ? 'result borderline' : 'result';
       div.innerHTML = `
         <div><span class="score"></span><span class="author"></span></div>
@@ -1017,6 +1025,11 @@
         c => Number.parseInt(c.querySelector('.score').textContent, 10) < post.score
       );
       if (after) after.before(div); else body.append(div);
+      while (body.children.length > MAX_PANEL_RESULTS) {
+        const last = body.lastElementChild;
+        if (last.dataset.urn) rendered.delete(last.dataset.urn);
+        last.remove();
+      }
     }
     return { setStatus, bump, addResult, showHint, hideHint, refreshControls, clearResults };
   })();


### PR DESCRIPTION
Third mitigation candidate for #63 Symptom A. PR #66 narrowed observer scope; PR #68 added marker-skip in rescan to bound async fan-out. Both helped (v0.3.7 lasted significantly longer before crashing) but the crash still recurs at extended sessions.

Remaining unbounded sink: the result card panel. Every \`addResult\` call appends a card to \`#lks-body\` — no cap, no virtualization. Long sessions accumulate hundreds of cards (boot history loop renders up to 50 immediately, then every fresh hit, every previously-scored re-encounter, every borderline on top). Each card is innerHTML + 4 child elements + 240-char snippet text. The DOM cost compounds with whatever else accumulates over time and eventually pushes the renderer over the edge.

## Fix

Cap at \`MAX_PANEL_RESULTS = 200\`. Insert is score-descending; when count exceeds the cap, evict the last (lowest-score) card.

\`\`\`js
const MAX_PANEL_RESULTS = 200;
function addResult(post) {
  // ... existing insert logic with div.dataset.urn = post.urn ...
  while (body.children.length > MAX_PANEL_RESULTS) {
    const last = body.lastElementChild;
    if (last.dataset.urn) rendered.delete(last.dataset.urn);
    last.remove();
  }
}
\`\`\`

The evicted post still exists in IDB (\`dbAllScored\` returns it), so the history view shows everything. The \`seen\` Set in \`tryCapture\` prevents the urn from being re-walked this session, so the eviction doesn't cause card thrashing.

Counters \`hits\` and \`scored\` do NOT decrement on eviction — they reflect \"matches found this session,\" not \"currently displayed.\"

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` / \`smoke\` — clean, smoke 5/5
- [ ] CI green
- [ ] Live: maintainer runs an extended session — past whatever threshold the previous build crashed at. Expect the panel to stabilize at exactly 200 cards visible after enough hits surface.

## If this still crashes

Then the crash isn't the panel either, and we need a Performance-tab capture before any further blind mitigation. Open candidates after this exhaust: in-memory queue back-pressure, Chrome MV3 SW lifecycle issues with connectNative, IDB transaction queue depth.

Mitigates #63 Symptom A.