### PR TITLE
chore: bump version to v0.3.8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Release bump for the panel-cap mitigation in #70.

## What's in v0.3.8

- **#70** — `fix: cap visible result cards at 200 to bound panel DOM growth`. Third mitigation candidate for #63 Symptom A. After #66 (observer scope) and #68 (rescan marker-skip), the remaining accumulation sink was the panel DOM itself: every scored hit, borderline, previously-scored re-render, and boot history entry appended a card to `#lks-body` without bound. `MAX_PANEL_RESULTS = 200`; insert order is score-descending, eviction drops the lowest-score tail. Evicted posts still live in IDB and surface via the History view.

Touches `package.json` and `manifest.json` only.