### PR TITLE
chore: bump version to v0.3.9

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Release bump for the bounded-retry + visibility-aware-pause mitigation in #72.

## What's in v0.3.9

- **#72** — `fix: bound scoring retries and pause work on hidden tabs`. Fourth mitigation candidate for #63 Symptom A. Maintainer reported the tab going hot in background and unresponsive on refocus even with v0.3.8. Two compounding causes:
  1. `maybeFlush` retried failed batches forever — non-quota errors put the batch back, slept 15 s, and recursed. In a background tab where Chrome MV3 kills the SW, every flush failed and the deferred retries thunderstormed on refocus. Capped at 3 consecutive errors → `Scoring stalled; click Resume.`
  2. Auto-scroll tick and `maybeFlush` ignored `document.visibilityState`. Now early-exit on hidden, with a `visibilitychange` listener kicking `maybeFlush` once on visible.

Touches `package.json` and `manifest.json` only.