### PR TITLE
fix: recycle LinkedIn DOM via auto-reload + auto-resume to bound crash exposure

### DIFF
--- a/content.js
+++ b/content.js
@@ -32,7 +32,8 @@
     scrollMinMs: 3000,
     scrollMaxMs: 6000,
     batchSize: 8,
-    maxPosts: 1500,
+    maxPosts: 200,
+    autoReloadOnCap: true,
   };
   const CFG = {};
   for (const k of Object.keys(DEFAULTS)) {
@@ -595,7 +596,21 @@
         stable = 0; lastH = h;
       }
       if (seen.size - postsAtStart >= CFG.maxPosts) {
-        stopScroll(); ui.setStatus(`maxPosts=${CFG.maxPosts} reached.`); maybeFlush(true); return;
+        // LinkedIn does not virtualize its feed; long auto-scroll sessions
+        // grow the page DOM unbounded until the renderer crashes (#63).
+        // We can't stop LinkedIn from doing that, but we can recycle the
+        // tab on a fixed cadence so it never reaches the crash zone. Queue
+        // and IDB persist across the reload so the next boot continues
+        // from where this one stopped.
+        stopScroll();
+        maybeFlush(true);
+        if (CFG.autoReloadOnCap) {
+          ui.setStatus(`Session cap (${CFG.maxPosts}) reached. Refreshing tab in 5s to recycle LinkedIn DOM…`);
+          setTimeout(() => globalThis.location.reload(), 5000);
+        } else {
+          ui.setStatus(`Session cap (${CFG.maxPosts}) reached. Refresh tab to continue.`);
+        }
+        return;
       }
       const delay = CFG.scrollMinMs + Math.random() * (CFG.scrollMaxMs - CFG.scrollMinMs);
       scrollTimer = setTimeout(tick, delay);

--- a/content.js
+++ b/content.js
@@ -599,16 +599,21 @@
         // LinkedIn does not virtualize its feed; long auto-scroll sessions
         // grow the page DOM unbounded until the renderer crashes (#63).
         // We can't stop LinkedIn from doing that, but we can recycle the
-        // tab on a fixed cadence so it never reaches the crash zone. Queue
-        // and IDB persist across the reload so the next boot continues
-        // from where this one stopped.
+        // tab on a fixed cadence so it never reaches the crash zone.
+        //
+        // This is NOT a hard session limit. Queue and IDB persist across
+        // the reload, the resume flag below tells the next boot to call
+        // startScroll() automatically once the queue is drained, and the
+        // user effectively gets a continuous session — just bounced
+        // through periodic invisible DOM recycles.
         stopScroll();
         maybeFlush(true);
         if (CFG.autoReloadOnCap) {
-          ui.setStatus(`Session cap (${CFG.maxPosts}) reached. Refreshing tab in 5s to recycle LinkedIn DOM…`);
+          localStorage.setItem(NS + 'resumeOnBoot', '1');
+          ui.setStatus(`Recycling LinkedIn DOM (every ${CFG.maxPosts} posts) — refreshing tab in 5s, scrolling will auto-resume…`);
           setTimeout(() => globalThis.location.reload(), 5000);
         } else {
-          ui.setStatus(`Session cap (${CFG.maxPosts}) reached. Refresh tab to continue.`);
+          ui.setStatus(`Cap (${CFG.maxPosts}) reached. Refresh tab to continue.`);
         }
         return;
       }
@@ -1118,8 +1123,19 @@
     }
     const anyStored = await dbAllScored(0);
     if (anyStored.length === 0) ui.showHint();
-    ui.setStatus(queuedFromDisk.length > 0
-      ? `Ready. ${queuedFromDisk.length} carried over — click Start.`
-      : 'Ready. Click Start.');
+    // Auto-resume after a DOM-recycle reload. The previous session segment
+    // hit maxPosts and bounced the tab; pick up scrolling automatically so
+    // the user sees a continuous capture session despite the reload.
+    if (localStorage.getItem(NS + 'resumeOnBoot') === '1') {
+      localStorage.removeItem(NS + 'resumeOnBoot');
+      ui.setStatus('Resuming after DOM recycle…');
+      // Wait a beat for the feed to mount and any queued posts to start
+      // flowing through the observer; then kick scrolling.
+      setTimeout(() => startScroll(), 1500);
+    } else {
+      ui.setStatus(queuedFromDisk.length > 0
+        ? `Ready. ${queuedFromDisk.length} carried over — click Start.`
+        : 'Ready. Click Start.');
+    }
   })();
 })();


### PR DESCRIPTION
After four direct mitigations of #63 Symptom A (#66, #68, #70, #72) the long-session tab crash kept recurring. The remaining unbounded sink is **outside the extension**: LinkedIn's React feed does not virtualize, so the page DOM grows linearly with how far the user scrolls until the renderer process is killed. We can't fix LinkedIn from inside the page, but we can bound how long any single page lifetime is exposed to that growth.

## Approach

Bound each page lifetime to a small, fixed number of captures (\`maxPosts\` default 1500 → 200), then **transparently recycle the tab** on hit:

- \`stopScroll\` + \`maybeFlush(true)\`
- write a \`resumeOnBoot\` flag to localStorage
- 5 s status announcement, then \`location.reload()\`
- boot loop reads the flag, clears it, and calls \`startScroll()\` after the feed has had a beat to mount

Queue and IDB already persist across reloads; the boot loop drains \`queuedFromDisk\` and rehydrates the panel from \`dbAllScored\`. The user sees a brief blink every ~200 captures, otherwise the session feels continuous, and the full day's feed is captured across many DOM-recycle segments accumulated in IDB.

This is **not a session limit** — it's a DOM-recycling cadence. \`autoReloadOnCap\` (default true) lets a determined user opt out by setting it to false in localStorage, in which case the cap behaves like the old just-stop-and-wait.

## Why this approach

The maintainer's directive was \"make the bug not affect our software,\" not \"diagnose LinkedIn's behaviour.\" Four iterations of speculative content-script optimisation didn't kill the crash. Bounding tab lifetime before the crash window does. The user's stated goal — capture the full day's feed — is preserved by the auto-resume.

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` / \`smoke\` — clean, smoke 5/5
- [ ] CI green
- [ ] Live: extended session. Expect: tab blinks every ~200 captures, scrolling auto-resumes, no thermals, no crash. Final IDB content matches what a non-crashing 1500-post run would have produced.

Closes #63 by mitigation rather than root cause.