### PR TITLE
chore: bump version to v0.3.10

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Release bump for the DOM-recycle pattern in #74.

## What's in v0.3.10

- **#74** — `fix: recycle LinkedIn DOM via auto-reload + auto-resume to bound crash exposure`. Final mitigation for #63 Symptom A. After four content-script optimisations, the underlying LinkedIn behaviour (no feed virtualization → DOM grows linearly with scroll → renderer crashes after a long session) was determined to be out-of-scope. Workaround: cap each page lifetime at 200 captures, transparently `location.reload()`, and auto-resume scrolling on next boot via a `resumeOnBoot` localStorage flag. Queue and IDB persist across the bounce, so the user gets the full day's feed across multiple invisible DOM-recycle segments.

Touches `package.json` and `manifest.json` only.