### PR TITLE
fix: poll rescan every 2 s — MutationObserver alone is unreliable on this DOM

### DIFF
--- a/content.js
+++ b/content.js
@@ -32,7 +32,7 @@
     scrollMinMs: 3000,
     scrollMaxMs: 6000,
     batchSize: 8,
-    maxPosts: 200,
+    maxPosts: 100,
     autoReloadOnCap: true,
   };
   const CFG = {};
@@ -545,6 +545,19 @@
       }
     };
     rescan();
+    // Polling fallback. The MutationObserver alone does not reliably fire
+    // on this LinkedIn DOM — React reconciliation in some cases produces
+    // mutations the observer never wakes up on, so the capture pipeline
+    // stays silent even as the user is visibly scrolling and new posts
+    // are mounting. Polling rescues the pipeline. Marker-skip in the loop
+    // body means each tick is essentially free if MO already kept up
+    // (every visible text-box is marked, the for loop is a no-op);
+    // newly-mounted nodes are processed exactly once. Hidden-tab guard
+    // matches the auto-scroll tick so we don't burn CPU in background.
+    setInterval(() => {
+      if (document.visibilityState === 'hidden') return;
+      rescan();
+    }, 2000);
   }
 
   // ---------- Scroller (human-like pacing) ----------


### PR DESCRIPTION
After five iterations chasing CPU / DOM / retry / visibility issues for #63, instrumented logging in the install dir revealed the actual root cause: the MutationObserver bound to \`<main>\` with \`childList: true, subtree: true\` fires **exactly once at boot** and then stays silent even as the user is visibly scrolling and LinkedIn is mounting new post wrappers into the observed subtree. React reconciliation appears to update the DOM in a way the observer doesn't wake up on.

This invalidates the framing of #66, #68, #70, #72, #74 — each was fixing real-but-irrelevant code paths. The capture pipeline never ran after boot, so \`captured\` stuck at 0, queue stayed empty, scoring stayed inactive, and every CPU/DOM/retry mitigation was unobservable.

## Fix

Add a 2 s \`setInterval(rescan, ...)\` polling fallback alongside the MutationObserver. Marker-skip from #68 keeps each tick essentially free if MO already kept up (the for loop is a no-op against marked text-boxes); newly-mounted nodes get processed exactly once. Hidden-tab guard matches the auto-scroll tick (#72) so polling does no work in background.

## Companion change: lower default \`maxPosts\` to 100

Live testing showed RAM hitting ~4 GB and CPU saturating multiple cores BEFORE the v0.3.10 auto-reload at maxPosts=200 fired. Halving the cap halves the per-segment DOM growth window so the auto-reload triggers before LinkedIn's accumulated React state gets that heavy. \`maxPosts\` is still configurable in Settings; this only changes the default for fresh installs.

## Live verification

After the polling fix + maxPosts=100 deployed to the maintainer's install dir:
- Pipeline resumed within seconds of polling start
- Captured climbed to 169 within a single segment
- Scoring batches firing
- Auto-reload at the cap triggered cleanly — \"Recycling LinkedIn DOM (every 100 posts) — refreshing tab in 5s, scrolling will auto-resume…\"

## Test plan

- [x] \`npm run check\` / \`validate\` / \`lint\` / \`smoke\` — clean, smoke 5/5
- [ ] CI green
- [x] Live exercise — confirmed capture pipeline alive

Closes #63.