### PR TITLE
fix: pause auto-playing feed videos and lower maxPosts to 50

### DIFF
--- a/content.js
+++ b/content.js
@@ -32,7 +32,7 @@
     scrollMinMs: 3000,
     scrollMaxMs: 6000,
     batchSize: 8,
-    maxPosts: 100,
+    maxPosts: 50,
     autoReloadOnCap: true,
   };
   const CFG = {};
@@ -597,6 +597,18 @@
       // or future LinkedIn variants that scroll the document still work.
       const scroller = document.querySelector('main') || document.scrollingElement || document.body;
       scroller.scrollTo(0, scroller.scrollHeight);
+      // Pause every <video> in the feed before processing the rest of
+      // the tick. LinkedIn auto-plays inline videos as they scroll into
+      // view; left to its own devices, every post in a long auto-scroll
+      // session ends up with a continuously playing video on the main
+      // thread. Each running video adds CPU + GPU + decoder memory
+      // pressure, compounding with the React reconciliation cost as the
+      // feed DOM grows. LinkedIn re-starts a video when it next comes
+      // back into view (IntersectionObserver-driven), so this only
+      // affects the off-screen accumulation.
+      for (const v of document.querySelectorAll('video')) {
+        if (!v.paused) { try { v.pause(); } catch { /* not all videos accept programmatic pause */ } }
+      }
       document.querySelectorAll('button').forEach(b => {
         const t = (b.innerText || '').toLowerCase();
         if (t.includes('load more comment') || t.includes('show more replies')


### PR DESCRIPTION
Followup to #76. Polling rescued the capture pipeline and auto-reload at 100 prevents the eventual crash, but the laptop is still hot through every segment — RAM climbs to ~4 GB and CPU stays heavy. Two new mitigations.

## Pause auto-playing feed videos in the auto-scroll tick

LinkedIn auto-plays inline feed videos as they scroll into view. Left alone, a long auto-scroll session accumulates dozens of simultaneously running videos on the main thread, each running a decoder + repainting frames. After every scroll we now pause every `<video>` we find. LinkedIn re-starts it when it next comes back into view via its own IntersectionObserver, so the user-facing experience is unchanged; we only suppress the off-screen pile-up.

## Lower default maxPosts 100 → 50

Same DOM-recycle pattern from #74 with twice the recycle frequency. Half the time per segment for LinkedIn DOM and React state to grow → half the per-segment RAM/CPU peak. Trade-off: more frequent reload blinks. Configurable in Settings; default change only.

## Test plan

- [x] `npm run check` / `validate` / `lint` / `smoke` — clean, smoke 5/5
- [ ] CI green
- [ ] Live: extended session. Expect noticeably lower CPU + RAM peak per segment, more frequent reload blinks (~5 min instead of ~10 min).