### PR TITLE
fix: downgrade scoring-failure log from console.error to console.warn

### DIFF
--- a/content.js
+++ b/content.js
@@ -355,7 +355,13 @@
       ui.bump('scored', scored.length);
       ui.setStatus(scrollTimer ? 'Scrolling…' : 'Idle.');
     } catch (e) {
-      console.error('[Linkshit]', e);
+      // warn rather than error so transient Chrome MV3 service-worker
+      // lifecycle hiccups (cold-start sendMessage, port disconnected
+      // mid-batch as SW gets killed, etc.) don't badge the extension
+      // red on chrome://extensions. The bounded-retry / quotaPaused
+      // logic already handles real failures cleanly; the message stays
+      // visible in DevTools for genuine debugging.
+      console.warn('[Linkshit]', e);
       for (const p of batch) queue.unshift(p);
       if (e.code === 'quota_exhausted') {
         quotaPaused = true;


### PR DESCRIPTION
Maintainer reports v0.3.12 immediately badges the extension red on `chrome://extensions` with `content.js:358 (maybeFlush)` errors right after start. Root cause is the `console.error('[Linkshit]', e)` in the maybeFlush catch path firing on routine Chrome MV3 service-worker lifecycle hiccups (cold-start sendMessage, port disconnected as the SW gets killed). The bounded-retry from #72 already handles these cleanly; the log is purely diagnostic.

Downgrade to `console.warn`. Same visibility in DevTools console for genuine debugging, no red badge for routine SW restarts. The other catch in this file (`tryCapture`, line 484) is already warn from #65 — this brings them in sync.