### PR TITLE
chore: bump v0.3.13 — quiet warn + CSS animation kill for CPU

### DIFF
--- a/content.js
+++ b/content.js
@@ -15,6 +15,21 @@
 (() => {
   'use strict';
 
+  // ---------- CPU mitigation: disable LinkedIn animations / transitions ----------
+  // LinkedIn ships an enormous amount of CSS animation: skeleton loaders,
+  // hover effects, content fade-ins, count-up odometers, scroll-driven
+  // ticker rotations, and so on. With auto-scroll continuously triggering
+  // new content mounts, dozens of animations run in parallel on the
+  // compositor + main thread. Injecting a near-zero animation/transition
+  // duration globally is a known SPA performance trick and routinely cuts
+  // CPU by a large fraction on visually busy sites. UX impact: transitions
+  // snap instead of fade, but everything still works.
+  const __cpuStyle = document.createElement('style');
+  __cpuStyle.id = 'linkshit-no-animations';
+  __cpuStyle.textContent = '*, *::before, *::after { animation-duration: 0.001ms !important; animation-iteration-count: 1 !important; transition-duration: 0.001ms !important; scroll-behavior: auto !important; }';
+  const __mountStyle = () => { (document.head || document.documentElement).append(__cpuStyle); };
+  if (document.head) __mountStyle(); else document.addEventListener('DOMContentLoaded', __mountStyle, { once: true });
+
   // ---------- Config (persisted in localStorage) ----------
   const NS = 'linkshit.';
   const DEFAULTS = {
@@ -355,7 +370,13 @@
       ui.bump('scored', scored.length);
       ui.setStatus(scrollTimer ? 'Scrolling…' : 'Idle.');
     } catch (e) {
-      console.error('[Linkshit]', e);
+      // warn rather than error so transient Chrome MV3 service-worker
+      // lifecycle hiccups (cold-start sendMessage, port disconnected
+      // mid-batch as SW gets killed, etc.) don't badge the extension
+      // red on chrome://extensions. The bounded-retry / quotaPaused
+      // logic already handles real failures cleanly; the message stays
+      // visible in DevTools for genuine debugging.
+      console.warn('[Linkshit]', e);
       for (const p of batch) queue.unshift(p);
       if (e.code === 'quota_exhausted') {
         quotaPaused = true;

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Bundles two things into v0.3.13:

- Version bump for the `console.error` → `console.warn` fix in #81 (no more red badge on routine MV3 SW restarts).
- New: inject a global `*{animation-duration:0.001ms; transition-duration:0.001ms; scroll-behavior:auto}` stylesheet at the top of the content-script IIFE, before LinkedIn renders most of its visual chrome. Targets the maintainer's still-300%+ CPU after v0.3.12's video pause + maxPosts=50. LinkedIn's animation budget is not negligible — skeleton loaders, hover effects, fade-ins, count-up odometers, ticker rotations all running in parallel on every mounted post. Snapping them to ~0 is a known SPA-perf trick. Functionality unchanged; transitions just don't fade.