### PR TITLE
fix: keepalive ping in background SW to survive long native-host calls

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,6 +7,30 @@
 
 const HOST_NAME = 'com.replikanti.linkshit';
 
+// MV3 service workers go to sleep after ~30 s idle. While processing
+// `chrome.runtime.connectNative` traffic, Chrome should keep the worker
+// alive — but in practice, when the native host (claude CLI) takes
+// longer than the idle window to respond, Chrome can still kill the
+// SW mid-batch. The content script then sees:
+//   "A listener indicated an asynchronous response by returning true,
+//    but the message channel closed before a response was received"
+// and the bounded retry kicks in.
+//
+// Workaround: while we have any in-flight scoring port open, ping a
+// cheap chrome API every 20 s. Each call resets the idle timer. The
+// pattern is documented across MV3 keep-alive guides and is the
+// commonly accepted shape for long-running native-messaging work.
+let inFlight = 0;
+let keepAliveTimer = null;
+function startKeepAlive() {
+  if (keepAliveTimer) return;
+  keepAliveTimer = setInterval(() => chrome.runtime.getPlatformInfo(), 20000);
+}
+function stopKeepAlive() {
+  if (inFlight > 0) return;
+  if (keepAliveTimer) { clearInterval(keepAliveTimer); keepAliveTimer = null; }
+}
+
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg?.type !== 'score') return false;
 
@@ -19,6 +43,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       return;
     }
 
+    inFlight++;
+    startKeepAlive();
     try {
       const result = await sendAndAwait(port, {
         type: 'score',
@@ -30,6 +56,8 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       sendResponse({ ok: false, error: e.message });
     } finally {
       try { port.disconnect(); } catch { /* already gone */ }
+      inFlight--;
+      stopKeepAlive();
     }
   })();
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Closes a Chrome MV3 lifecycle gap that produces the warned message:
```
A listener indicated an asynchronous response by returning true,
but the message channel closed before a response was received
```

claude CLI scoring batches can take longer than Chrome's MV3 SW idle window (~30 s); the SW gets killed mid-batch even though connectNative is supposedly active. Content-script bounded retry catches it but we lose work for no good reason.

Standard MV3 keep-alive: ping `chrome.runtime.getPlatformInfo` every 20 s while any score port is in flight. Reference-counted so concurrent batches share one timer.