### PR TITLE
chore: bump v0.3.16 — halve batchSize default to spread CPU peaks

### DIFF
--- a/content.js
+++ b/content.js
@@ -46,7 +46,7 @@
     borderlineDelta: 2,
     scrollMinMs: 5000,
     scrollMaxMs: 10000,
-    batchSize: 8,
+    batchSize: 4,
     maxPosts: 50,
     autoReloadOnCap: true,
   };

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.15",
+  "version": "0.3.16",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Maintainer reports v0.3.15 brought baseline CPU under 100 % but peaks still hit ~500 % when LinkedIn React reconciliation + LLM batch response + result-card render all land on the main thread together.

Halve `batchSize` default 8 → 4. Each batch is half the work, the per-spike peak is roughly halved, batches fire twice as often. Practically that smooths the CPU graph without changing per-day capture throughput. User-overridable in Settings.

This is the last meaningful CPU lever from inside our extension. The remaining peak is LinkedIn's React reconciliation, which we can't optimize from a content script.