### PR TITLE
fix: make the LLM's reasoning explicit on every result + criteria visible

### DIFF
--- a/content.js
+++ b/content.js
@@ -817,7 +817,11 @@
     #lks-panel .result .author{font-weight:600}
     #lks-panel .result .score{float:right;background:var(--primary);color:var(--primary-fg);padding:1px 6px;
       border-radius:3px;font-size:11px}
-    #lks-panel .result .reason{font-style:italic;color:var(--reason);margin:2px 0}
+    #lks-panel .result .reason{color:var(--fg);margin:6px 0;padding:5px 8px;
+      background:var(--btn-bg);border-left:3px solid var(--primary);border-radius:0 3px 3px 0;
+      font-size:12px;line-height:1.45}
+    #lks-panel .result .reason::before{content:"Why this score: ";font-weight:600;color:var(--primary)}
+    #lks-panel .result .reason:empty{display:none}
     #lks-panel .result .snippet{color:var(--snippet);font-size:12px;max-height:64px;overflow:hidden}
     #lks-panel .result a{color:var(--primary);text-decoration:none;font-size:11px}
     #lks-panel .result .dismiss{float:right;margin-left:6px;background:transparent;border:none;color:var(--muted);
@@ -840,7 +844,7 @@
     panel.innerHTML = `
       <div id="lks-resize"></div>
       <header>
-        <span>Linkshit<span id="lks-profile-wrap" style="display:none"> · Profile: <select id="lks-profile" title="Active profile"></select></span></span>
+        <span><span id="lks-title" style="cursor:help;text-decoration:underline dotted">Linkshit</span><span id="lks-profile-wrap" style="display:none"> · Profile: <select id="lks-profile" title="Active profile"></select></span></span>
         <span>
           <button id="lks-start" class="primary">Start</button>
           <button id="lks-pause">Pause</button>
@@ -978,6 +982,15 @@
         if (p.name === profiles.activeName) opt.selected = true;
         sel.append(opt);
       }
+      // Surface the active criteria as the dropdown's tooltip so users
+      // can see what the LLM is judging posts against without having to
+      // open Settings. They reach for this when a Score: N/10 doesn't
+      // make sense to them.
+      sel.title = `Active criteria:\n\n${CFG.criteria || '(none)'}`;
+      // Same tooltip on the panel title — visible even when there's
+      // only one profile and the dropdown is hidden.
+      const titleEl = $('lks-title');
+      if (titleEl) titleEl.title = `Active criteria (LLM judges every post against this):\n\n${CFG.criteria || '(none)'}`;
       // Hide the whole "· Profile: [select]" affordance when a single profile
       // exists — at that point the dropdown is just a confusing title-suffix
       // with one inert option. It pops back the moment the user creates a
@@ -1016,11 +1029,15 @@
       row.dataset.score = p.score;
       if (p.status === 'dismissed') row.classList.add('dismissed');
       row.innerHTML = `
-        <div><span class="score" title="LLM-assigned relevance score 0–10 against your active criteria."></span><span class="author"></span><button class="dismiss" title="Dismiss this result">×</button></div>
+        <div><span class="score"></span><span class="author"></span><button class="dismiss" title="Dismiss this result">×</button></div>
         <div class="reason"></div>
         <div class="snippet"></div>
         <a target="_blank">Open on LinkedIn →</a>`;
-      row.querySelector('.score').textContent = `Score: ${p.score}/10`;
+      const scoreEl = row.querySelector('.score');
+      scoreEl.textContent = `Score: ${p.score}/10`;
+      scoreEl.title = p.reason
+        ? `LLM scored ${p.score}/10 because: ${p.reason}`
+        : `LLM scored ${p.score}/10 against your active criteria.`;
       row.querySelector('.author').textContent = p.author;
       row.querySelector('.reason').textContent = p.reason || '';
       row.querySelector('.snippet').textContent = (p.text || '').slice(0, 240);
@@ -1275,11 +1292,15 @@
       div.dataset.score = post.score;
       div.className = post.borderline ? 'result borderline' : 'result';
       div.innerHTML = `
-        <div><span class="score" title="LLM-assigned relevance score 0–10 against your active criteria."></span><span class="author"></span><button class="dismiss" title="Dismiss this result">×</button></div>
+        <div><span class="score"></span><span class="author"></span><button class="dismiss" title="Dismiss this result">×</button></div>
         <div class="reason"></div>
         <div class="snippet"></div>
         <a target="_blank">Open on LinkedIn →</a>`;
-      div.querySelector('.score').textContent = `Score: ${post.score}/10`;
+      const scoreEl = div.querySelector('.score');
+      scoreEl.textContent = `Score: ${post.score}/10`;
+      scoreEl.title = post.reason
+        ? `LLM scored ${post.score}/10 because: ${post.reason}`
+        : `LLM scored ${post.score}/10 against your active criteria.`;
       div.querySelector('.author').textContent = post.author;
       div.querySelector('.reason').textContent = post.reason;
       div.querySelector('.snippet').textContent = post.text.slice(0, 240);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.19",
+  "version": "0.3.20",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Maintainer feedback: "Score: 7/10" with a tooltip saying "LLM-assigned score 0-10" still doesn't tell them WHY the LLM gave that number or what it's judging against. Three changes:

## Reason styled as the explanation it is

The `reason` field on each result was small italic gray text, easy to miss. Now it's a block with `Why this score:` prepended, colored left border, light background. Reads as the explanation it actually is.

## Score badge tooltip is per-post

Hovering the score badge now shows `LLM scored 7/10 because: <post-specific reason>` instead of the generic "LLM-assigned score 0-10". You hover the number, you read the rationale for THAT exact post.

## Active criteria visible without opening Settings

Tooltip on the panel "Linkshit" title shows `Active criteria (LLM judges every post against this): <criteria text>`. `cursor:help` + dotted underline so users notice it. Same tooltip on the profile dropdown for multi-profile setups.