### PR TITLE
fix: Settings Save no longer re-hydrates panel from IDB

### DIFF
--- a/content.js
+++ b/content.js
@@ -1200,11 +1200,14 @@
       $('lks-settings').style.display = 'none';
       $('lks-body').style.display = historyMode ? 'none' : '';
       $('lks-history').style.display = historyMode ? '' : 'none';
-      // Re-apply the threshold / borderline filters to the live panel:
-      // the settings change otherwise leaves stale cards (e.g. borderline
-      // cards visible after the user turns Show borderline off, or 5-6
-      // score cards still showing after raising threshold to 7).
-      rehydrateLivePanel().then(() => setStatus('Settings saved.'));
+      // Save updates configuration only — it does NOT re-render the
+      // live panel. Earlier we rehydrated from IDB after Save so users
+      // saw the new filter applied, but that ignored an explicit
+      // Clear All: the user empties the panel, opens Settings, hits
+      // Save, and old hits come back from history. New filter applies
+      // to subsequent captures; if the user wants a clean slate against
+      // the new filter, Clear All. Existing cards stay until they do.
+      setStatus('Settings saved.');
     };
     $('s-cancel').onclick = () => {
       sync();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.25",
+  "version": "0.3.26",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
Save was overriding an explicit Clear All by re-rendering top 50 hits from IDB. Save now only updates config; future captures apply the new filter.