### PR TITLE
chore: separate Clear DB from Save/Cancel/Rescore

### DIFF
--- a/content.js
+++ b/content.js
@@ -869,6 +869,11 @@
       background:var(--field-bg);color:var(--fg);border:1px solid var(--field-border);
       border-radius:3px;padding:3px 5px}
     #lks-settings label{font-size:11px;color:var(--muted);display:block;margin-top:4px}
+    #lks-settings .actions-row{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px}
+    #lks-settings .actions-row button{margin-left:0}
+    #lks-settings .danger-row{margin-top:16px;padding-top:12px;
+      border-top:1px solid var(--border-subtle)}
+    #lks-settings .danger-row button{margin-left:0}
     #lks-pill{position:fixed;right:12px;top:80px;z-index:999999;display:none;
       padding:6px 12px;border-radius:999px;font:12px system-ui;cursor:pointer;
       background:#0a66c2;color:#fff;border:1px solid #084d92;
@@ -952,10 +957,14 @@
         <input id="s-scrollMinMs" type="number"/><input id="s-scrollMaxMs" type="number"/>
         <label>Batch size</label><input id="s-batchSize" type="number"/>
         <label>Max posts per session</label><input id="s-maxPosts" type="number"/>
-        <button id="s-save" class="primary">Save</button>
-        <button id="s-cancel">Cancel</button>
-        <button id="s-rescore">Rescore stored</button>
-        <button id="s-clear" class="danger">Clear DB (irreversible)</button>
+        <div class="actions-row">
+          <button id="s-save" class="primary">Save</button>
+          <button id="s-cancel">Cancel</button>
+          <button id="s-rescore">Rescore stored</button>
+        </div>
+        <div class="danger-row">
+          <button id="s-clear" class="danger">Clear DB (irreversible)</button>
+        </div>
       </div>`;
     document.body.append(panel);
     const $ = id => panel.querySelector('#' + id);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- The four Settings buttons sat on one row with a flat 4px gap between them, so the (red) Clear DB button looked visually fused with the safe Save / Cancel / Rescore buttons and wrapped onto a second row with no vertical breathing room on narrower panels.
- Split into two rows: `actions-row` (Save / Cancel / Rescore) at the top and `danger-row` (Clear DB) below, separated by a 16px top margin and a `border-top` divider. Colour + 'irreversible' label from v0.3.29 unchanged.
- Bumps to v0.3.31.

User feedback that prompted this: "Clear DB je hrozne priplacnute k ostatnim buttons... neni tam vubec zadna mezera..."

## Test plan
- [ ] Open Settings — Save / Cancel / Rescore stored sit on one row, Clear DB sits on its own row below a divider line.
- [ ] Resize panel narrow — actions-row wraps cleanly via flex; danger-row stays separated.
- [ ] Dark mode — divider line uses `--border-subtle`, visible on both palettes.
- [ ] Click Clear DB — confirmation flow unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)