### PR TITLE
feat: 'filtered' counter so users see why queued stays 0

### DIFF
--- a/content.js
+++ b/content.js
@@ -550,6 +550,13 @@
         ui.setQueued(queue.length);
         maybeFlush();
       } else {
+        // Post passed all "structural" skips (promoted/company/old/dedup)
+        // but didn't match the user's keyword/author/reactions pre-filter.
+        // Surface this explicitly: without a counter the user just sees
+        // captured climbing while queued/scored stay at zero and assumes
+        // scoring is broken, when actually their keyword list is too
+        // narrow for the kind of posts in their feed.
+        ui.bump('filtered', 1);
         await dbPut(post);
       }
     } catch (e) {
@@ -920,6 +927,7 @@
         <span title="Posts skipped because they were sponsored / Promoted.">promoted <b id="lks-c-promoted">0</b></span>
         <span title="Posts skipped because they were authored by a company page (toggle in Settings).">company <b id="lks-c-company">0</b></span>
         <span title="Posts skipped by the age filter (when enabled).">old <b id="lks-c-tooOld">0</b></span>
+        <span title="Posts that survived the basic skips (not promoted, not company, not too old, not already in DB) but failed your pre-filter — the keyword list / author allowlist / min-reactions in Settings. If this is high while queued+scored stay 0, your keyword list probably doesn't match the kind of posts in your feed: clear the keyword field to send everything to the LLM.">filtered <b id="lks-c-filtered">0</b></span>
         <span title="Posts in the queue waiting to be scored. Live count — drops as scoring drains it.">queued <b id="lks-c-queued">0</b></span>
         <span title="Posts the LLM has assigned a score to in this session.">scored <b id="lks-c-scored">0</b></span>
         <span title="Scored posts that crossed the score threshold and got rendered.">hits <b id="lks-c-hits">0</b></span>
@@ -1060,7 +1068,7 @@
         panel.style.width = newWidth + 'px';
       });
     });
-    const counters = { captured: 0, promoted: 0, company: 0, tooOld: 0, queued: 0, scored: 0, hits: 0 };
+    const counters = { captured: 0, promoted: 0, company: 0, tooOld: 0, filtered: 0, queued: 0, scored: 0, hits: 0 };
     // Track URNs already rendered in the panel so the boot replay + later
     // scroll-into-view of the same post don't produce duplicate rows.
     const rendered = new Set();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.31",
+  "version": "0.3.32",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- A user reported captured=149 / queued=0 / scored=0 / hits=0 — pipeline looked broken from the panel.
- It wasn't broken: every captured post failed the keyword pre-filter (default `ai, recruit, sourc, hir, engineer, llm, startup, founder`) so was stored to IDB but never queued for the LLM. There was no counter exposing this rejection, so the user had no way to tell.
- Adds a `filtered` counter between `old` and `queued`. The tooltip says: *Posts that survived the basic skips … but failed your pre-filter — keyword list / author allowlist / min-reactions in Settings. If this is high while queued+scored stay 0, your keyword list probably doesn't match the kind of posts in your feed: clear the keyword field to send everything to the LLM.*
- Math invariant: `captured = filtered + queued + scored` (over a full session, ignoring in-flight scoring).

## Test plan
- [ ] Default install on a feed with no AI/recruit content — `filtered` climbs alongside `captured`, `queued`+`scored` stay 0.
- [ ] Clear the keyword field in Settings → Save — every new post now goes into `queued`.
- [ ] Hover the `filtered` counter — tooltip explains the cause and the fix.
- [ ] Boot replay (rehydrate) doesn't double-count `filtered`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)