### PR TITLE
fix: wrap counter row so 'filtered' is visible

### DIFF
--- a/content.js
+++ b/content.js
@@ -839,7 +839,8 @@
     #lks-panel button.danger:hover{background:#b71c1c}
     #lks-panel .status{padding:6px 12px;font-size:12px;color:var(--muted);background:var(--status-bg);
       border-top:1px solid var(--border-subtle);border-bottom:1px solid var(--border-subtle)}
-    #lks-panel .counters{padding:6px 12px;font-size:11px;color:var(--muted-2);display:flex;gap:12px;
+    #lks-panel .counters{padding:6px 12px;font-size:11px;color:var(--muted-2);display:flex;
+      flex-wrap:wrap;gap:6px 12px;
       border-bottom:1px solid var(--border-subtle)}
     #lks-panel .counters span{cursor:help;text-decoration:underline dotted;text-decoration-color:var(--muted)}
     #lks-panel .hint{padding:10px 12px;font-size:12px;color:var(--hint-fg);background:var(--hint-bg);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- v0.3.32 added the `filtered` counter but the user reported they couldn't see it on the panel.
- Cause: `.counters` is `display:flex` with no `flex-wrap`, so eight counters overflow the 380px default panel width and `filtered` ends up clipped past the right edge.
- Fix: add `flex-wrap:wrap` and split `gap` into row/column components (6px / 12px) so the counters flow onto a second line when they don't fit. Same total horizontal spacing as before; only the wrap behaviour changes.
- Bumps to v0.3.33.

## Test plan
- [ ] Default 380px panel — counters fit on two rows, `filtered` is visible.
- [ ] Resized to >700px — all counters fit on one row, layout unchanged from v0.3.32.
- [ ] Resized to 280px (min) — counters wrap onto multiple rows without clipping.
- [ ] Dark mode — same wrap behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)