### PR TITLE
feat: break filtered counter down by reason in its tooltip

### DIFF
--- a/content.js
+++ b/content.js
@@ -300,13 +300,18 @@
   }
 
   // ---------- Pre-filter ----------
+  // Returns { ok, reason }. The reason is what the panel surfaces in the
+  // `filtered` tooltip so the user can tell at a glance which check
+  // they're tripping — opaque "filtered=N, queued=0" was leaving people
+  // unable to diagnose why nothing reached the LLM.
   function preFilter(p) {
-    if (!p.text || p.text.length < 30) return false;
-    if (p.reactions < CFG.minReactions) return false;
+    if (!p.text || p.text.length < 30) return { ok: false, reason: 'shortText' };
+    if (p.reactions < CFG.minReactions) return { ok: false, reason: 'lowReactions' };
+    if (CFG.authors.length && CFG.authors.some(a => p.author.toLowerCase().includes(a.toLowerCase()))) return { ok: true };
     const hay = (p.author + ' ' + p.text).toLowerCase();
-    if (CFG.authors.length && CFG.authors.some(a => p.author.toLowerCase().includes(a.toLowerCase()))) return true;
-    if (CFG.keywords.length && CFG.keywords.some(k => hay.includes(k.toLowerCase()))) return true;
-    return CFG.keywords.length === 0 && CFG.authors.length === 0;
+    if (CFG.keywords.length && CFG.keywords.some(k => hay.includes(k.toLowerCase()))) return { ok: true };
+    if (CFG.keywords.length === 0 && CFG.authors.length === 0) return { ok: true };
+    return { ok: false, reason: 'noMatch' };
   }
 
   // ---------- Orphan-content-script detection ----------
@@ -543,7 +548,8 @@
         return;
       }
       ui.bump('captured', 1);
-      if (preFilter(post)) {
+      const pf = preFilter(post);
+      if (pf.ok) {
         post.status = 'queued';
         await dbPut(post);
         queue.push(post);
@@ -557,6 +563,7 @@
         // scoring is broken, when actually their keyword list is too
         // narrow for the kind of posts in their feed.
         ui.bump('filtered', 1);
+        ui.bumpFilterReason(pf.reason);
         await dbPut(post);
       }
     } catch (e) {
@@ -1435,6 +1442,29 @@
       $('lks-pause').disabled = !scrollTimer;
     }
     refreshControls();
+    // Per-cause breakdown of pre-filter rejections. Shown in the
+    // `filtered` counter's tooltip so the user can tell at a glance
+    // whether their keyword list, min-reactions, or post-length check
+    // is the one swallowing every captured post.
+    const filterReasons = { lowReactions: 0, noMatch: 0, shortText: 0 };
+    const filteredEl = $('lks-c-filtered')?.parentElement;
+    const FILTERED_BASE_TIP = filteredEl?.title || '';
+    function refreshFilteredTooltip() {
+      if (!filteredEl) return;
+      const r = filterReasons;
+      filteredEl.title = FILTERED_BASE_TIP +
+        `\n\nBreakdown:` +
+        `\n  no keyword/author match: ${r.noMatch}` +
+        `\n  too few reactions (LinkedIn 2026-05 DOM no longer exposes the reaction count, so any min-reactions > 0 rejects everything): ${r.lowReactions}` +
+        `\n  text too short: ${r.shortText}`;
+    }
+    refreshFilteredTooltip();
+    function bumpFilterReason(reason) {
+      if (reason in filterReasons) {
+        filterReasons[reason] += 1;
+        refreshFilteredTooltip();
+      }
+    }
     function bump(name, n) {
       counters[name] = (counters[name] || 0) + n;
       const el = $('lks-c-' + name);
@@ -1516,7 +1546,7 @@
       }
       pillHitsEl.textContent = String(counters.hits);
     }
-    return { setStatus, bump, setQueued, addResult, showHint, hideHint, refreshControls, clearResults, clearBodyOnly, getCounters, setCounters, setPillRunning };
+    return { setStatus, bump, bumpFilterReason, setQueued, addResult, showHint, hideHint, refreshControls, clearResults, clearBodyOnly, getCounters, setCounters, setPillRunning };
   })();
 
   // ---------- Live-panel rehydration ----------

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.33",
+  "version": "0.3.34",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- A user reported captured=456 / filtered=456 / queued=0 with no way to tell *which* preFilter check was the culprit.
- preFilter now returns `{ok, reason}` instead of a bare bool, and the panel keeps per-cause sub-counts (`noMatch`, `lowReactions`, `shortText`).
- The `filtered` counter's tooltip appends a live breakdown:
  ```
  Breakdown:
    no keyword/author match: N
    too few reactions (LinkedIn 2026-05 DOM no longer exposes the
      reaction count, so any min-reactions > 0 rejects everything): N
    text too short: N
  ```
- The reactions line is load-bearing: since the May 2026 DOM rewrite, `extractPost` hardcodes `reactions=0` because the count moved off the public DOM. Any user with min-reactions > 0 from an old session has been silently rejecting every post.
- Bumps to v0.3.34.

## Test plan
- [ ] Default settings (keywords set, minReactions=0) — hovering `filtered` shows `noMatch=N` if posts don't contain default keywords.
- [ ] Set minReactions=10 → all posts go to `lowReactions=N`.
- [ ] Clear keywords + minReactions=0 → no posts go to `filtered`; everything queues.
- [ ] Tooltip refreshes as the counter ticks (Chrome re-reads the title attr on next hover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)