### PR TITLE
feat: log boot config + auto-warn on starved pipeline

### DIFF
--- a/content.js
+++ b/content.js
@@ -1459,10 +1459,31 @@
         `\n  text too short: ${r.shortText}`;
     }
     refreshFilteredTooltip();
+    // Latch a warning once — we want to flag the broken pipeline but not
+    // overwrite every fresh status message after the user has seen it.
+    let prefilterWarned = false;
     function bumpFilterReason(reason) {
       if (reason in filterReasons) {
         filterReasons[reason] += 1;
         refreshFilteredTooltip();
+        // Auto-diagnose: filtered climbing while queued+scored stay 0
+        // means the pre-filter is gating the entire pipeline. Surface
+        // it directly in the status line so the user doesn't have to
+        // read the breakdown tooltip to notice.
+        if (!prefilterWarned
+            && counters.filtered >= 20
+            && counters.queued === 0
+            && counters.scored === 0) {
+          prefilterWarned = true;
+          const top = Object.entries(filterReasons).sort((a, b) => b[1] - a[1])[0];
+          const cause = top && top[1] > 0 ? top[0] : 'noMatch';
+          const fix = cause === 'lowReactions'
+            ? 'Set Min reactions to 0 in ⚙ — LinkedIn 2026-05 DOM no longer exposes reaction counts.'
+            : cause === 'shortText'
+              ? 'Posts have very short text; adjust your feed or wait for longer posts.'
+              : 'Clear the Pre-filter keywords field in ⚙ — your keywords don\'t match this feed.';
+          setStatus(`⚠ Pre-filter is rejecting everything (${cause}). ${fix}`);
+        }
       }
     }
     function bump(name, n) {
@@ -1579,6 +1600,23 @@
 
   // ---------- Boot ----------
   (async () => {
+    // One-shot dump of the active config when the script loads. Users
+    // diagnosing "nothing reaches the LLM" can open DevTools → Console
+    // and immediately see what keywords / minReactions / scoreThresh
+    // the system actually has — instead of guessing whether their
+    // saved settings drifted from the defaults shown in the UI.
+    console.info('[linkshit] boot config:', {
+      version: '0.3.35',
+      criteria: (CFG.criteria || '').slice(0, 120),
+      keywords: CFG.keywords,
+      authors: CFG.authors,
+      minReactions: CFG.minReactions,
+      maxAgeHours: CFG.maxAgeHours,
+      scoreThresh: CFG.scoreThresh,
+      skipCompanyPosts: CFG.skipCompanyPosts,
+      batchSize: CFG.batchSize,
+      maxPosts: CFG.maxPosts,
+    });
     // Drain any queued-but-not-scored posts left over from a previous session
     // BEFORE starting the observer, so the observer can't race on the same
     // URN. seen.add prevents a later DOM re-encounter from re-queueing.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Linkshit",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApyY5xhnWfT/r3UK34waLo+1jAMr7qetraziKoLZsX6ie3l55aQbSxESupuUh1wGsQ4qrF+BayGs6yLfF7LFYdhFw8I9CJfWHaRXo0MntyFwmhWl073mUz8nB45xsTJP2bOzrTITcLM6MCSrb4mzw7XfCU5m3nhhbddrWFMWnrxrUOJLkd6PWVKX3A2xaJUjKgBPGiF0o5LT+hZHrUaeR//+u3Jvh048/wZE8GacdhMHtHCP5n/lUD3RY74L7lnFeRT/V+yNW8uvyOyXctw10HH3Ub02aVIudPRcD4RcGcL/3k84P6WOyMb9yIlmckYQnBNaPjURAeRTlF8Q70P/ZPQIDAQAB",
   "permissions": ["nativeMessaging"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linkshit",
-  "version": "0.3.34",
+  "version": "0.3.35",
   "description": "Linkshit — auto-scroll your LinkedIn feed and surface posts matching your criteria via a local LLM.",
   "main": "host.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- User reports captured=456 / filtered=456 / queued=0 across multiple sessions and insists settings haven't changed. The v0.3.34 breakdown tooltip exists but requires a hover to read.
- Adds two diagnostics:
  1. `console.info('[linkshit] boot config:', {…})` on every page load — keywords, authors, minReactions, maxAgeHours, scoreThresh, skipCompanyPosts, batchSize, maxPosts. Open DevTools and see what's actually in localStorage without trusting the Settings UI to mirror it.
  2. Auto-warning in the status line when `filtered ≥ 20` while `queued + scored = 0`. Picks the dominant rejection reason from the breakdown and writes a clear, actionable one-liner: `⚠ Pre-filter is rejecting everything (noMatch). Clear the Pre-filter keywords field in ⚙ — your keywords don't match this feed.` Latched so it doesn't fight a fresh status update after the user acts.
- Bumps to v0.3.35.

## Test plan
- [ ] Boot — check Console: `[linkshit] boot config: {…}` line shows current settings.
- [ ] Set a non-matching keyword (e.g. `xyzzy`) and scroll until 20+ posts captured — status flips to the warning.
- [ ] Clear keywords + Save — status no longer pinned to warning when next captures bump it.
- [ ] Set minReactions=10 → warning shows `(lowReactions)` and points at min-reactions fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)